### PR TITLE
fix(QueuedJobService): Fix when a job hits the "Job releasing memory and …

### DIFF
--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -680,7 +680,7 @@ class QueuedJobService
                     $jobDescriptor->write();
                 }
 
-                if (!$broken) {
+                if ($job->jobFinished()) {
                     $job->afterComplete();
                     $jobDescriptor->cleanupJob();
                 }


### PR DESCRIPTION
fix(QueuedJobService): Fix when a job hits the "Job releasing memory and waiting" case and completed successfully, it would not run the 'afterComplete' logic.