### PR TITLE
Update Travis configuration, add namespaces to Test classes, fix bug with QJService shutdown function in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,31 @@
-# See https://github.com/silverstripe/silverstripe-travis-support for setup details
-
-sudo: false
-
 language: php
 
-php:
-  - 5.6
-  - 7.0
-  - 7.1
-
 env:
-  - DB=MYSQL CORE_RELEASE=4
-  - DB=PGSQL CORE_RELEASE=4
+  global:
+    - COMPOSER_ROOT_VERSION="4.0.x-dev"
+
+matrix:
+  include:
+    - php: 5.6
+      env: DB=MYSQL PHPCS_TEST=1 PHPUNIT_TEST=1
+    - php: 7.0
+      env: DB=PGSQL PHPUNIT_TEST=1
+    - php: 7.1
+      env: DB=MYSQL PHPUNIT_TEST=1
 
 before_script:
-  - composer self-update || true
-  - git clone git://github.com/silverstripe/silverstripe-travis-support.git ~/travis-support
-  - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss
-  - cd ~/builds/ss
-  - composer install
+  - phpenv rehash
+  - phpenv config-rm xdebug.ini
+
+  - composer install --prefer-dist
+  - composer require --prefer-dist --no-update silverstripe/recipe-cms:1.0.x-dev
+  - if [[ $DB == PGSQL ]]; then composer require --prefer-dist --no-update silverstripe/postgresql:2.0.x-dev; fi
+  - composer update
 
 script:
-  - vendor/bin/phpunit queuedjobs/tests
+  - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit; fi
+  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml; fi
+  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs --standard=framework/phpcs.xml.dist src/ tests/ ; fi
+
+after_success:
+  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi

--- a/_config.php
+++ b/_config.php
@@ -1,5 +1,1 @@
 <?php
-
-if (($queuedJobsDir = basename(dirname(__FILE__))) != 'queuedjobs') {
-    die("The queued jobs module must be installed in /queuedjobs, not {$queuedJobsDir}");
-}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,10 @@
         "silverstripe/admin": "^1@dev",
         "asyncphp/doorman": "^3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^5.7",
+        "squizlabs/php_codesniffer": "^3.0"
+    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "extra": {
@@ -32,7 +36,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Symbiote\\QueuedJobs\\": "src/"
+            "Symbiote\\QueuedJobs\\": "src/",
+            "Symbiote\\QueuedJobs\\Tests\\": "tests/"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,14 @@
-<!--
-Standard module phpunit configuration.
-Requires PHPUnit ^5.7
--->
 <phpunit bootstrap="framework/tests/bootstrap.php" colors="true">
-        <testsuite name="Default">
-                <directory>tests</directory>
+    <testsuite name="Default">
+        <directory>tests/</directory>
     </testsuite>
+
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src/</directory>
+            <exclude>
+                <directory suffix=".php">tests/</directory>
+            </exclude>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/Services/JobErrorHandler.php
+++ b/src/Services/JobErrorHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Symbiote\QueuedJobs\Services;
+
+use Exception;
+
+/**
+ * Class used to handle errors for a single job
+ */
+class JobErrorHandler
+{
+    public function __construct()
+    {
+        set_error_handler(array($this, 'handleError'));
+    }
+
+    public function clear()
+    {
+        restore_error_handler();
+    }
+
+    public function handleError($errno, $errstr, $errfile, $errline)
+    {
+        if (error_reporting()) {
+            // Don't throw E_DEPRECATED in PHP 5.3+
+            if (defined('E_DEPRECATED')) {
+                if ($errno == E_DEPRECATED || $errno = E_USER_DEPRECATED) {
+                    return;
+                }
+            }
+
+            switch ($errno) {
+                case E_NOTICE:
+                case E_USER_NOTICE:
+                case E_STRICT:
+                    break;
+                default:
+                    throw new Exception($errstr . " in $errfile at line $errline", $errno);
+                    break;
+            }
+        }
+    }
+}

--- a/src/Tasks/CreateQueuedJobTask.php
+++ b/src/Tasks/CreateQueuedJobTask.php
@@ -5,7 +5,7 @@ namespace Symbiote\QueuedJobs\Tasks;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Dev\BuildTask;
 use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
-use Symbiote\QueuedJobs\Services\QueuedJob;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
 
 /**
  * A task that can be used to create a queued job.
@@ -38,7 +38,7 @@ class CreateQueuedJobTask extends BuildTask
     }
 
     /**
-     * @param SS_HTTPRequest $request
+     * @param HTTPRequest $request
      */
     public function run($request)
     {
@@ -55,73 +55,13 @@ class CreateQueuedJobTask extends BuildTask
             if ($start >= $now) {
                 $friendlyStart = date('Y-m-d H:i:s', $start);
                 echo "Job ".$request['name']. " queued to start at: <b>".$friendlyStart."</b>";
-                singleton('Symbiote\\QueuedJobs\\Services\\QueuedJobService')->queueJob($job, $start);
+                singleton(QueuedJobService::class)->queueJob($job, $start);
             } else {
                 echo "'start' parameter must be a date/time in the future, parseable with strtotime";
             }
         } else {
             echo "Job Queued";
-            singleton('Symbiote\\QueuedJobs\\Services\\QueuedJobService')->queueJob($job);
-        }
-    }
-}
-
-class DummyQueuedJob extends AbstractQueuedJob implements QueuedJob
-{
-    /**
-     * @param int $number
-     */
-    public function __construct($number = 0)
-    {
-        if ($number) {
-            $this->startNumber = $number;
-            $this->totalSteps = $this->startNumber;
-        }
-    }
-
-    /**
-     * @return string
-     */
-    public function getTitle()
-    {
-        return "Some test job for ".$this->startNumber.' seconds';
-    }
-
-    /**
-     * @return string
-     */
-    public function getJobType()
-    {
-        return QueuedJob::QUEUED;
-    }
-
-    public function setup()
-    {
-        // just demonstrating how to get a job going...
-        $this->totalSteps = $this->startNumber;
-        $this->times = array();
-    }
-
-    public function process()
-    {
-        $times = $this->times;
-        // needed due to quirks with __set
-        $times[] = date('Y-m-d H:i:s');
-        $this->times = $times;
-
-        $this->addMessage("Updated time to " . date('Y-m-d H:i:s'));
-        sleep(1);
-
-        // make sure we're incrementing
-        $this->currentStep++;
-
-        // if ($this->currentStep > 1) {
-        //     $this->currentStep = 1;
-        // }
-
-        // and checking whether we're complete
-        if ($this->currentStep >= $this->totalSteps) {
-            $this->isComplete = true;
+            singleton(QueuedJobService::class)->queueJob($job);
         }
     }
 }

--- a/src/Tasks/DummyQueuedJob.php
+++ b/src/Tasks/DummyQueuedJob.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Symbiote\QueuedJobs\Tasks;
+
+use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
+use Symbiote\QueuedJobs\Services\QueuedJob;
+
+class DummyQueuedJob extends AbstractQueuedJob implements QueuedJob
+{
+    /**
+     * @param int $number
+     */
+    public function __construct($number = 0)
+    {
+        if ($number) {
+            $this->startNumber = $number;
+            $this->totalSteps = $this->startNumber;
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle()
+    {
+        return 'Some test job for ' . $this->startNumber . ' seconds';
+    }
+
+    /**
+     * @return string
+     */
+    public function getJobType()
+    {
+        return QueuedJob::QUEUED;
+    }
+
+    public function setup()
+    {
+        // just demonstrating how to get a job going...
+        $this->totalSteps = $this->startNumber;
+        $this->times = array();
+    }
+
+    public function process()
+    {
+        $times = $this->times;
+        // needed due to quirks with __set
+        $times[] = date('Y-m-d H:i:s');
+        $this->times = $times;
+
+        $this->addMessage('Updated time to ' . date('Y-m-d H:i:s'));
+        sleep(1);
+
+        // make sure we're incrementing
+        $this->currentStep++;
+
+        // if ($this->currentStep > 1) {
+        //     $this->currentStep = 1;
+        // }
+
+        // and checking whether we're complete
+        if ($this->currentStep >= $this->totalSteps) {
+            $this->isComplete = true;
+        }
+    }
+}

--- a/tests/AbstractTest.php
+++ b/tests/AbstractTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symbiote\QueuedJobs\Tests;
+
+use SilverStripe\Dev\SapphireTest;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
+
+abstract class AbstractTest extends SapphireTest
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        // The shutdown handler doesn't play nicely with SapphireTest's database handling
+        QueuedJobService::config()->set('use_shutdown_function', false);
+    }
+}

--- a/tests/CleanupJobTest.php
+++ b/tests/CleanupJobTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Symbiote\QueuedJobs\Tests;
+
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\ORM\FieldType\DBDatetime;
@@ -8,7 +10,7 @@ use Symbiote\QueuedJobs\Jobs\CleanupJob;
 /**
  * @author Andrew Aitken-Fincham <andrew@silverstripe.com>
  */
-class CleanupJobTest extends SapphireTest
+class CleanupJobTest extends AbstractTest
 {
     /**
      * {@inheritDoc}
@@ -19,7 +21,7 @@ class CleanupJobTest extends SapphireTest
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         // Have to set a fake time here to work with
         // the LastEdited dates in the fixture
@@ -30,7 +32,7 @@ class CleanupJobTest extends SapphireTest
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    protected function tearDown()
     {
         parent::tearDown();
         DBDatetime::clear_mock_now();
@@ -39,11 +41,11 @@ class CleanupJobTest extends SapphireTest
     public function testByDays()
     {
         $job = new CleanupJob();
-        Config::modify()->set('Symbiote\\QueuedJobs\\Jobs\\CleanupJob', 'cleanup_method', 'age');
-        Config::modify()->set('Symbiote\\QueuedJobs\\Jobs\\CleanupJob', 'cleanup_value', 30);
-        Config::inst()->remove('Symbiote\\QueuedJobs\\Jobs\\CleanupJob', 'cleanup_statuses');
+        Config::modify()->set(CleanupJob::class, 'cleanup_method', 'age');
+        Config::modify()->set(CleanupJob::class, 'cleanup_value', 30);
+        Config::inst()->remove(CleanupJob::class, 'cleanup_statuses');
         Config::modify()->set(
-            'Symbiote\\QueuedJobs\\Jobs\\CleanupJob',
+            CleanupJob::class,
             'cleanup_statuses',
             array('Broken', 'Complete')
         );
@@ -55,11 +57,11 @@ class CleanupJobTest extends SapphireTest
     public function testByNumber()
     {
         $job = new CleanupJob();
-        Config::modify()->set('Symbiote\\QueuedJobs\\Jobs\\CleanupJob', 'cleanup_method', 'number');
-        Config::modify()->set('Symbiote\\QueuedJobs\\Jobs\\CleanupJob', 'cleanup_value', 3);
-        Config::inst()->remove('Symbiote\\QueuedJobs\\Jobs\\CleanupJob', 'cleanup_statuses');
+        Config::modify()->set(CleanupJob::class, 'cleanup_method', 'number');
+        Config::modify()->set(CleanupJob::class, 'cleanup_value', 3);
+        Config::inst()->remove(CleanupJob::class, 'cleanup_statuses');
         Config::modify()->set(
-            'Symbiote\\QueuedJobs\\Jobs\\CleanupJob',
+            CleanupJob::class,
             'cleanup_statuses',
             array('Broken', 'Complete')
         );
@@ -71,11 +73,11 @@ class CleanupJobTest extends SapphireTest
     public function testByStatus()
     {
         $job = new CleanupJob();
-        Config::modify()->set('Symbiote\\QueuedJobs\\Jobs\\CleanupJob', 'cleanup_method', 'number');
-        Config::modify()->set('Symbiote\\QueuedJobs\\Jobs\\CleanupJob', 'cleanup_value', 3);
-        Config::inst()->remove('Symbiote\\QueuedJobs\\Jobs\\CleanupJob', 'cleanup_statuses');
+        Config::modify()->set(CleanupJob::class, 'cleanup_method', 'number');
+        Config::modify()->set(CleanupJob::class, 'cleanup_value', 3);
+        Config::inst()->remove(CleanupJob::class, 'cleanup_statuses');
         Config::modify()->set(
-            'Symbiote\\QueuedJobs\\Jobs\\CleanupJob',
+            CleanupJob::class,
             'cleanup_statuses',
             array('Broken', 'Complete', 'New')
         );
@@ -87,11 +89,11 @@ class CleanupJobTest extends SapphireTest
     public function testNoCleanup()
     {
         $job = new CleanupJob();
-        Config::modify()->set('Symbiote\\QueuedJobs\\Jobs\\CleanupJob', 'cleanup_method', 'number');
-        Config::modify()->set('Symbiote\\QueuedJobs\\Jobs\\CleanupJob', 'cleanup_value', 6);
-        Config::inst()->remove('Symbiote\\QueuedJobs\\Jobs\\CleanupJob', 'cleanup_statuses');
+        Config::modify()->set(CleanupJob::class, 'cleanup_method', 'number');
+        Config::modify()->set(CleanupJob::class, 'cleanup_value', 6);
+        Config::inst()->remove(CleanupJob::class, 'cleanup_statuses');
         Config::modify()->set(
-            'Symbiote\\QueuedJobs\\Jobs\\CleanupJob',
+            CleanupJob::class,
             'cleanup_statuses',
             array('Broken', 'Complete', 'New')
         );

--- a/tests/QueuedJobsTest/TestQJService.php
+++ b/tests/QueuedJobsTest/TestQJService.php
@@ -23,7 +23,7 @@ class TestQJService extends QueuedJobService implements TestOnly
         return $this->initialiseJob($descriptor);
     }
 
-    public function getLogger() 
+    public function getLogger()
     {
         return isset($this->logger) ? $this->logger : $this->logger = new QueuedJobsTest_RecordingLogger();
     }

--- a/tests/ScheduledExecutionTest.php
+++ b/tests/ScheduledExecutionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Symbiote\QueuedJobs\Tests;
+
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\DataObject;
 use Symbiote\QueuedJobs\Tests\ScheduledExecutionTest\TestScheduledDataObject;
@@ -8,7 +10,7 @@ use Symbiote\QueuedJobs\Tests\ScheduledExecutionTest\TestScheduledDataObject;
  * @author marcus@symbiote.com.au
  * @license BSD License http://silverstripe.org/bsd-license/
  */
-class ScheduledExecutionTest extends SapphireTest
+class ScheduledExecutionTest extends AbstractTest
 {
     /**
      * We need the DB for this test


### PR DESCRIPTION
* Move DummyQueuedJob and JobErrorHandler into their own files
* Apply PSR-2 linting to remaining files
* Remove code coverage run for now

I've removed the standard code coverage run from the Travis config template, which normally uses phpdbg on PHP 7.1 - I've done this because there are two integration tests that consistently fail with coverage runs enabled. Using Xdebug we still have a failure but in a different integration test. I'll log this issue separately.