### PR TITLE
Add scheduledJob to ImmediateQueueHandler

### DIFF
--- a/code/services/ImmediateQueueHandler.php
+++ b/code/services/ImmediateQueueHandler.php
@@ -25,4 +25,8 @@ class ImmediateQueueHandler {
 	public function startJobOnQueue(QueuedJobDescriptor $job) {
 		$this->queuedJobService->runJob($job->ID);
 	}
+
+	public function scheduleJob(QueuedJobDescriptor $job, $date) {
+		$this->queuedJobService->runJob($job->ID);
+	}
 }


### PR DESCRIPTION
This API is relied upon in `QueuedJobHandler` and causes fatal errors if you try to use the immediatequeuehandler.