### PR TITLE
Remove PHP 5.3 from Travis config, add 7.0 and 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,26 +4,18 @@ sudo: false
 
 language: php
 
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-
-env:
-  - DB=MYSQL CORE_RELEASE=3.2
-
 matrix:
   include:
-    - php: 5.6
+    - php: 5.4
       env: DB=MYSQL CORE_RELEASE=3
-    - php: 5.6
+    - php: 5.5
       env: DB=MYSQL CORE_RELEASE=3.1
     - php: 5.6
       env: DB=PGSQL CORE_RELEASE=3.2
-  allow_failures:
     - php: 7.0
+      env: DB=MYSQL CORE_RELEASE=3.6
+    - php: 7.1
+      env: DB=MYSQL CORE_RELEASE=3.6
 
 before_script:
   - composer self-update || true


### PR DESCRIPTION
PHP 5.3 is unsupported on trusty in Travis, and the precise distro will be removed in a few months