### PR TITLE
NEW: Allow queueing of build tasks

### DIFF
--- a/_config/taskrunner.yml
+++ b/_config/taskrunner.yml
@@ -1,0 +1,9 @@
+---
+Name: QueuedDevelopmentAdmin
+---
+DevelopmentAdmin:
+  registered_controllers:
+    tasks:
+      controller: 'QueuedTaskRunner'
+      links:
+        tasks: 'See a list of build tasks to run (QueuedJobs version)'

--- a/code/controllers/QueuedTaskRunner.php
+++ b/code/controllers/QueuedTaskRunner.php
@@ -1,0 +1,123 @@
+<?php
+
+class QueuedTaskRunner extends TaskRunner
+{
+
+    private static $url_handlers = array(
+        'queue/$TaskName' => 'queueTask'
+    );
+
+    private static $allowed_actions = array(
+        'queueTask'
+    );
+
+    private static $task_blacklist = array(
+        'ProcessJobQueueTask',
+        'ProcessJobQueueChildTask',
+        'CreateQueuedJobTask',
+    );
+
+    public function index()
+    {
+        $tasks = $this->getTasks();
+
+        $blacklist = (array)$this->config()->task_blacklist;
+        $backlistedTasks = array();
+
+        // Web mode
+        if(!Director::is_cli()) {
+            $renderer = new DebugView();
+            $renderer->writeHeader();
+            $renderer->writeInfo("SilverStripe Development Tools: Tasks (QueuedJobs version)", Director::absoluteBaseURL());
+            $base = Director::absoluteBaseURL();
+
+            echo "<div class=\"options\">";
+            echo "<h2>Queueable jobs</h2>\n";
+            echo "<p>By default these jobs will be added the job queue, rather than run immediately</p>\n";
+            echo "<ul>";
+            foreach ($tasks as $task) {
+                if (in_array($task['class'], $blacklist)) {
+                    $backlistedTasks[] = $task;
+                    continue;
+                }
+
+                $queueLink = $base . "dev/tasks/queue/" . $task['segment'];
+                $immediateLink = $base . "dev/tasks/" . $task['segment'];
+
+                echo "<li><p>";
+                echo "<a href=\"$queueLink\">" . $task['title'] . "</a> <a style=\"font-size: 80%; padding-left: 20px\" href=\"$immediateLink\">[run immediately]</a><br />";
+                echo "<span class=\"description\">" . $task['description'] . "</span>";
+                echo "</p></li>\n";
+            }
+            echo "</ul></div>";
+
+            echo "<div class=\"options\">";
+            echo "<h2>Non-queueable tasks</h2>\n";
+            echo "<p>These tasks shouldn't be added the queuejobs queue, but you can run them immediately.</p>\n";
+            echo "<ul>";
+            foreach ($backlistedTasks as $task) {
+                $immediateLink = $base . "dev/tasks/" . $task['segment'];
+
+                echo "<li><p>";
+                echo "<a href=\"$immediateLink\">" . $task['title'] . "</a><br />";
+                echo "<span class=\"description\">" . $task['description'] . "</span>";
+                echo "</p></li>\n";
+            }
+            echo "</ul></div>";
+
+            $renderer->writeFooter();
+
+        // CLI mode - revert to default behaviour
+        } else {
+            return parent::index();
+        }
+    }
+
+
+    /**
+     * Adds a RunBuildTaskJob to the job queue for a given task
+     * @param SS_HTTPRequest $request
+     */
+    public function queueTask($request)
+    {
+        $name = $request->param('TaskName');
+        $tasks = $this->getTasks();
+
+        $variables = $request->getVars();
+        unset($variables['url']);
+        unset($variables['flush']);
+        unset($variables['flushtoken']);
+        unset($variables['isDev']);
+        $querystring = http_build_query($variables);
+
+        $title = function ($content) {
+            printf(Director::is_cli() ? "%s\n\n" : '<h1>%s</h1>', $content);
+        };
+
+        $message = function ($content) {
+            printf(Director::is_cli() ? "%s\n" : '<p>%s</p>', $content);
+        };
+
+        foreach ($tasks as $task) {
+            if ($task['segment'] == $name) {
+                $inst = Injector::inst()->create($task['class']); /** @var BuildTask $inst */
+                if (!$inst->isEnabled()) {
+                    $message('The task is disabled');
+                    return;
+                }
+
+                $title(sprintf('Queuing Task %s', $inst->getTitle()));
+
+                $job = new RunBuildTaskJob($task['class'], $querystring);
+                $jobID = Injector::inst()->get('QueuedJobService')->queueJob($job);
+
+                $message('Done: queued with job ID ' . $jobID);
+                $adminLink = Director::baseURL() . "admin/queuedjobs/QueuedJobDescriptor";
+                $message("Visit <a href=\"$adminLink\">queued jobs admin</a> to see job status");
+                return;
+            }
+        }
+
+        $message(sprintf('The build task "%s" could not be found', Convert::raw2xml($name)));
+    }
+}

--- a/code/controllers/QueuedTaskRunner.php
+++ b/code/controllers/QueuedTaskRunner.php
@@ -15,6 +15,7 @@ class QueuedTaskRunner extends TaskRunner
         'ProcessJobQueueTask',
         'ProcessJobQueueChildTask',
         'CreateQueuedJobTask',
+        'DeleteAllJobsTask',
     );
 
     public function index()

--- a/code/dataobjects/QueuedJobDescriptor.php
+++ b/code/dataobjects/QueuedJobDescriptor.php
@@ -111,7 +111,7 @@ class QueuedJobDescriptor extends DataObject {
 			'StartAfter' => _t('QueuedJobs.TABLE_START_AFTER', 'Start After'),
 			'JobType'	=> _t('QueuedJobs.JOB_TYPE', 'Job Type'),
 			'JobStatus' => _t('QueuedJobs.TABLE_STATUS', 'Status'),
-			'Messages' => _t('QueuedJobs.TABLE_MESSAGES', 'Message'),
+			'LastMessage' => _t('QueuedJobs.TABLE_MESSAGES', 'Message'),
 			'StepsProcessed' => _t('QueuedJobs.TABLE_NUM_PROCESSED', 'Done'),
 			'TotalSteps' => _t('QueuedJobs.TABLE_TOTAL', 'Total'),
 		);
@@ -213,14 +213,29 @@ class QueuedJobDescriptor extends DataObject {
 	}
 
 	/**
+     * Get all job messages as an HTML unordered list.
 	 * @return string|void
 	 */
 	public function getMessages() {
 		if (strlen($this->SavedJobMessages)) {
 			$msgs = @unserialize($this->SavedJobMessages);
-			return is_array($msgs) ? '<ul><li>'.implode('</li><li>', $msgs).'</li></ul>' : '';
+			return is_array($msgs) ? '<ul><li>'.nl2br(implode('</li><li>', Convert::raw2xml($msgs))).'</li></ul>' : '';
 		}
 	}
+
+    /**
+     * Get the last job message as a raw string
+     * @return string|void
+     */
+    public function getLastMessage() {
+        if (strlen($this->SavedJobMessages)) {
+            $msgs = @unserialize($this->SavedJobMessages);
+            if (is_array($msgs) && sizeof($msgs)) {
+                $msg = array_pop($msgs);
+                return $msg;
+            }
+        }
+    }
 
 	/**
 	 * @return string
@@ -259,6 +274,10 @@ class QueuedJobDescriptor extends DataObject {
 
 		$fields->removeByName('SavedJobData');
 		$fields->removeByName('SavedJobMessages');
+
+        if (strlen($this->SavedJobMessages)) {
+            $fields->addFieldToTab('Root.Messages', new LiteralField('Messages', $this->getMessages()));
+        }
 
 		if (Permission::check('ADMIN')) {
 			return $fields;

--- a/code/jobs/RunBuildTaskJob.php
+++ b/code/jobs/RunBuildTaskJob.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * A job used to delete a data object. Typically used for deletes that need to happen on
+ * a schedule, or where the delete may have some onflow affect that takes a while to
+ * finish the deletion.
+ *
+ * @author marcus@symbiote.com.au
+ * @license BSD License http://silverstripe.org/bsd-license/
+ */
+class RunBuildTaskJob extends AbstractQueuedJob {
+    /**
+     * @param DataObject $node
+     */
+    public function __construct($taskClass = null, $queryString = null) {
+        if ($taskClass) {
+            $this->TaskClass = $taskClass;
+        }
+
+        if ($queryString) {
+            $this->QueryString = $queryString;
+        }
+
+        $this->currentStep = 0;
+        $this->totalSteps = 1;
+    }
+
+    /**
+     * @param string (default: Object)
+     * @return DataObject
+     */
+    protected function getObject($name = 'Object') {
+        return DataObject::get_by_id($this->TargetClass, $this->TargetID);
+    }
+
+    /**
+     * @return string
+     */
+    public function getJobType() {
+        return QueuedJob::QUEUED;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle() {
+        $taskName = $this->QueryString ? ($this->TaskClass . '?' . $this->QueryString) : $this->TaskClass;
+        return _t('RunBuildTaskJob.JOB_TITLE', 'Run BuildTask {task}', array('task' => $taskName));
+    }
+
+    public function process() {
+        if (!is_subclass_of($this->TaskClass, 'BuildTask')) {
+            throw new \LogicException($this->TaskClass . ' is not a build task');
+        }
+
+        $task = Injector::inst()->create($this->TaskClass);
+        if (!$task->isEnabled()) {
+            throw new \LogicException($this->TaskClass . ' is not enabled');
+        }
+
+        $getVars = array();
+        parse_str($this->QueryString, $getVars);
+        $request = new SS_HTTPRequest('GET', '/', $getVars);
+        $task->run($request);
+
+        $this->currentStep = 1;
+        $this->isComplete = true;
+    }
+}

--- a/code/tasks/DeleteAllJobsTask.php
+++ b/code/tasks/DeleteAllJobsTask.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * An administrative task to delete all queued jobs records from the database.
+ * Use with caution!
+ */
+class DeleteAllJobsTask extends BuildTask
+{
+
+    /**
+     * @inheritdoc
+     * @return string
+     */
+    public function getTitle()
+    {
+        return "Delete all queued jobs.";
+    }
+
+    /**
+     * @inheritdoc
+     * @return string
+     */
+    public function getDescription()
+    {
+        return "Remove all queued jobs from the database. Use with caution!";
+    }
+
+    /**
+     * Run the task
+     * @param SS_HTTPRequest $request
+     */
+    public function run($request)
+    {
+        $confirm = $request->getVar('confirm');
+
+        $jobs = DataObject::get('QueuedJobDescriptor');
+
+        if (!$confirm) {
+            echo "Really delete " . $jobs->count() . " jobs? Please add ?confirm=1 to the URL to confirm.";
+            return;
+        }
+
+        echo "Deleting " . $jobs->count() . " jobs...<br>\n";
+        $jobs->removeAll();
+        echo "Done.";
+    }
+}

--- a/code/tasks/engines/BaseRunner.php
+++ b/code/tasks/engines/BaseRunner.php
@@ -42,15 +42,15 @@ class BaseRunner {
 	 */
 	protected function logDescriptorStatus($descriptor, $queue) {
 		if(is_null($descriptor)) {
-			$this->writeLogLine('No new jobs');
+			$this->writeLogLine('No new jobs on queue ' . $queue);
 		}
 
 		if($descriptor === false) {
-			$this->writeLogLine('Job is still running on ' . $queue);
+			$this->writeLogLine('Job is still running on queue ' . $queue);
 		}
 
 		if($descriptor instanceof QueuedJobDescriptor) {
-			$this->writeLogLine('Running ' . $descriptor->JobTitle . ' and others from ' . $queue . '.');
+			$this->writeLogLine('Running ' . $descriptor->JobTitle . ' and others from queue ' . $queue . '.');
 		}
 	}
 


### PR DESCRIPTION
This adds a couple of items:

 * A job type RunBuildTaskJob, that will run a single build task
 * A QueuedTaskRunner, that overrides the default dev/tasks admin in non-CLI mode, to allow queuing of build tasks by default

The result is that when queued jobs is installed, web management of build tasks will by default happen on background job queues. This will simplify the deployment of SilverStripe sites to servers where the dev team don’t have SSH access.

Fixes #150