### PR TITLE
NEW Convert to vendor module, update use of cli-script with sake and some readme examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
       env: DB=PGSQL PHPUNIT_TEST=1
     - php: 7.1
       env: DB=MYSQL PHPUNIT_TEST=1
+    - php: 7.2
+      env: DB=MYSQL PHPUNIT_TEST=1
 
 before_script:
   - phpenv rehash

--- a/_config/queuedjobs.yml
+++ b/_config/queuedjobs.yml
@@ -4,17 +4,22 @@ Name: queuedjobsettings
 SilverStripe\Core\Injector\Injector:
   QueueHandler:
     class: Symbiote\QueuedJobs\Services\DefaultQueueHandler
+  DoormanRunner:
+    class: Symbiote\QueuedJobs\Tasks\Engines\DoormanRunner
+
   Symbiote\QueuedJobs\Services\QueuedJobService:
     properties:
       queueHandler: %$QueueHandler
       # Change to %$DoormanRunner for async processing (requires *nix)
       queueRunner: %$Symbiote\QueuedJobs\Tasks\Engines\QueueRunner
+
   DefaultRule:
     class: 'AsyncPHP\Doorman\Rule\InMemoryRule'
     properties:
       Processes: 1
       MinimumProcessorUsage: 0
       MaximumProcessorUsage: 100
+
   Symbiote\QueuedJobs\Tasks\Engines\DoormanRunner:
     properties:
       DefaultRules:
@@ -29,8 +34,10 @@ SilverStripe\Core\Injector\Injector:
   Symbiote\QueuedJobs\Services\GearmanQueueHandler:
     properties:
       gearmanService: %$GearmanService
+
   Symbiote\QueuedJobs\Workers\JobWorker:
     properties:
       queuedJobService: %$Symbiote\QueuedJobs\Services\QueuedJobService
+
   QueueHandler:
     class: GearmanQueueHandler

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "symbiote/silverstripe-queuedjobs",
     "description": "A framework for defining and running background jobs in a queued manner",
-    "type": "silverstripe-module",
+    "type": "silverstripe-vendormodule",
     "keywords": ["silverstripe", "jobs"],
     "license": "BSD-3-Clause",
     "authors": [
@@ -15,8 +15,8 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "^4@dev",
-        "silverstripe/admin": "^1@dev",
+        "silverstripe/framework": "^4",
+        "silverstripe/admin": "^1",
         "asyncphp/doorman": "^3.0"
     },
     "require-dev": {
@@ -26,7 +26,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "extra": {
-        "installer-name": "queuedjobs",
+        "expose": ["images"],
         "branch-alias": {
             "dev-master": "4.x-dev"
         }

--- a/scripts/lsyncd-config.sample
+++ b/scripts/lsyncd-config.sample
@@ -9,7 +9,7 @@ settings = {
 
 -- Define the command and path for the each system being monitored here, where webuser is the user your webserver
 -- runs as
-runcmd = "/sbin/runuser webuser -c \"/usr/bin/php /var/www/sitepath/framework/cli-script.php dev/tasks/ProcessJobQueueTask job=\"$1\" /var/www/sitepath/framework/silverstripe-cache/queuedjobs\""
+runcmd = "/sbin/runuser webuser -c \"/usr/bin/php /var/www/sitepath/vendor/bin/sake dev/tasks/ProcessJobQueueTask job=\"$1\" /var/www/sitepath/framework/silverstripe-cache/queuedjobs\""
 
 site_processor = {
 	onCreate = function(event)

--- a/scripts/queue_processor.init
+++ b/scripts/queue_processor.init
@@ -40,7 +40,7 @@ start() {
 	for PATH in ${SILVERSTRIPE_ROOT[@]};
 	do
 	INOTIFY_OPTS="--monitor --event attrib -q"
-	INOTIFY_ARGS="--format 'php ${PATH}/framework/cli-script.php dev/tasks/ProcessJobQueueTask job=%f' ${PATH}/silverstripe-cache/queuedjobs | /bin/sh"
+	INOTIFY_ARGS="--format 'php ${PATH}/vendor/bin/sake dev/tasks/ProcessJobQueueTask job=%f' ${PATH}/silverstripe-cache/queuedjobs | /bin/sh"
 			daemon --user apache /usr/bin/inotifywait ${INOTIFY_OPTS} ${INOTIFY_ARGS} &
 			/bin/touch /var/lock/subsys/queue_processor
 		done

--- a/scripts/run-queued-jobs.sh
+++ b/scripts/run-queued-jobs.sh
@@ -7,4 +7,4 @@
 SILVERSTRIPE_ROOT=/path/to/silverstripe
 SILVERSTRIPE_CACHE=/path/to/silverstripe-cache
 
-inotifywait --monitor --event attrib --format "php $SILVERSTRIPE_ROOT/framework/cli-script.php dev/tasks/ProcessJobQueueTask job=%f" $SILVERSTRIPE_CACHE/queuedjobs | sh
+inotifywait --monitor --event attrib --format "php $SILVERSTRIPE_ROOT/vendor/bin/sake dev/tasks/ProcessJobQueueTask job=%f" $SILVERSTRIPE_CACHE/queuedjobs | sh

--- a/src/Controllers/QueuedJobsAdmin.php
+++ b/src/Controllers/QueuedJobsAdmin.php
@@ -42,7 +42,7 @@ class QueuedJobsAdmin extends ModelAdmin
     /**
      * @var string
      */
-    private static $menu_icon = "queuedjobs/images/clipboard.png";
+    private static $menu_icon = "symbiote/silverstripe-queuedjobs:images/clipboard.png";
 
     /**
      * @var array

--- a/src/DataObjects/QueuedJobDescriptor.php
+++ b/src/DataObjects/QueuedJobDescriptor.php
@@ -127,7 +127,7 @@ class QueuedJobDescriptor extends DataObject
             'JobTitle' => _t(__CLASS__ . '.TABLE_TITLE', 'Title'),
             'Created' => _t(__CLASS__ . '.TABLE_ADDE', 'Added'),
             'JobStarted' => _t(__CLASS__ . '.TABLE_STARTED', 'Started'),
-//			'JobRestarted' => _t(__CLASS__ . '.TABLE_RESUMED', 'Resumed'),
+//          'JobRestarted' => _t(__CLASS__ . '.TABLE_RESUMED', 'Resumed'),
             'StartAfter' => _t(__CLASS__ . '.TABLE_START_AFTER', 'Start After'),
             'JobType'   => _t(__CLASS__ . '.JOB_TYPE', 'Job Type'),
             'JobStatus' => _t(__CLASS__ . '.TABLE_STATUS', 'Status'),

--- a/src/Tasks/Engines/DoormanRunner.php
+++ b/src/Tasks/Engines/DoormanRunner.php
@@ -48,7 +48,7 @@ class DoormanRunner extends BaseRunner implements TaskRunnerEngine
         // split jobs out into multiple tasks...
 
         $manager = new ProcessManager();
-        $manager->setWorker(BASE_PATH . "/framework/cli-script.php dev/tasks/ProcessJobQueueChildTask");
+        $manager->setWorker(BASE_PATH . "/vendor/bin/sake dev/tasks/ProcessJobQueueChildTask");
         // $manager->setLogPath(__DIR__);
 
         // Assign default rules


### PR DESCRIPTION
Summary of changes:

* Convert to vendor module -> module will be installed into `vendor/symbiote/silverstripe-queuedjobs`
* Images directory will be "exposed" (symlinked into resources folder for public access outside of vendor folder)
* Added PHP 7.2 to the Travis build matrix
* Update readme examples and file paths that reference cli-script.php to use `vendor/bin/sake`