### PR TITLE
reinstate fallback to 0 for runasID post-ss4

### DIFF
--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -183,7 +183,13 @@ class QueuedJobService
         $jobDescriptor->Implementation = get_class($job);
         $jobDescriptor->StartAfter = $startAfter;
 
-        $jobDescriptor->RunAsID = $userId ? $userId : Security::getCurrentUser()->ID;
+        $runAsID = 0;
+        if ($userId) {
+            $runAsID = $userId;
+        } elseif (Security::getCurrentUser() && Security::getCurrentUser()->exists()) {
+            $runAsID = Security::getCurrentUser()->ID;
+        }
+        $jobDescriptor->RunAsID = $runAsID;
 
         // copy data
         $this->copyJobToDescriptor($job, $jobDescriptor);


### PR DESCRIPTION
Since the SS4 upgrade, you can't generate a job via CLI because of this error:

```
PHP Notice:  Trying to get property of non-object in /vagrant/www/vendor/symbiote/silverstripe-queuedjobs/src/Services/QueuedJobService.php on line 186
```

For example, in staticpublishqueue, I can't run the [StaticCacheFullBuildTask](https://github.com/silverstripe/silverstripe-staticpublishqueue/blob/master/src/Task/StaticCacheFullBuildTask.php#L87) via CLI successfully. This is because in the SS3 version, the fallback if there was no `$userID` passed in was `Member::getCurrentUserID()` - which would return `0` if there was no member i.e. it was run via CLI. Since this has been changed to `Security::getCurrentUser()->ID`, we get the above error. This PR re-introduces the fallback.