### PR TITLE
Check that Security::getCurrentUser() returns not null before accessing property

### DIFF
--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -183,7 +183,11 @@ class QueuedJobService
         $jobDescriptor->Implementation = get_class($job);
         $jobDescriptor->StartAfter = $startAfter;
 
-        $jobDescriptor->RunAsID = $userId ? $userId : Security::getCurrentUser()->ID;
+        if ($userId === null) {
+            $userId = (Security::getCurrentUser() ? Security::getCurrentUser()->ID : null);
+        }
+
+        $jobDescriptor->RunAsID = $userId;
 
         // copy data
         $this->copyJobToDescriptor($job, $jobDescriptor);


### PR DESCRIPTION
`QueuedJobService::queueJob()` is making the assumption that a `User` will always be provided or available through `Security::getCurrentUser()`, but `QueuedJobService::runJob()` does not require a `User` to be set, and a `User` might not need to be provided for Jobs queued through a cron.