### PR TITLE
Log QueuedJob errors with context provided.

### DIFF
--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -361,7 +361,11 @@ class QueuedJobService
                         'errcontext' => array()
                     ),
                     true
-                )
+                ),
+                [
+                    'file' => __FILE__,
+                    'line' => __LINE__,
+                ]
             );
         }
     }
@@ -385,7 +389,13 @@ class QueuedJobService
             );
             foreach ($this->defaultJobs as $title => $jobConfig) {
                 if (!isset($jobConfig['filter']) || !isset($jobConfig['type'])) {
-                    $this->getLogger()->error("Default Job config: $title incorrectly set up. Please check the readme for examples");
+                    $this->getLogger()->error(
+                        "Default Job config: $title incorrectly set up. Please check the readme for examples",
+                        [
+                            'file' => __FILE__,
+                            'line' => __LINE__,
+                        ]
+                    );
                     continue;
                 }
                 $job = $activeJobs->filter(array_merge(
@@ -393,7 +403,13 @@ class QueuedJobService
                     $jobConfig['filter']
                 ));
                 if (!$job->count()) {
-                    $this->getLogger()->error("Default Job config: $title was missing from Queue");
+                    $this->getLogger()->error(
+                        "Default Job config: $title was missing from Queue",
+                        [
+                            'file' => __FILE__,
+                            'line' => __LINE__,
+                        ]
+                    );
                     Email::create()
                         ->setTo(isset($jobConfig['email']) ? $jobConfig['email'] : Config::inst()->get('Email', 'queued_job_admin_email'))
                         ->setFrom(Config::inst()->get('Email', 'queued_job_admin_email'))
@@ -405,14 +421,26 @@ class QueuedJobService
                         ->send();
                     if (isset($jobConfig['recreate']) && $jobConfig['recreate']) {
                         if (!array_key_exists('construct', $jobConfig) || !isset($jobConfig['startDateFormat']) || !isset($jobConfig['startTimeString'])) {
-                            $this->getLogger()->error("Default Job config: $title incorrectly set up. Please check the readme for examples");
+                            $this->getLogger()->error(
+                                "Default Job config: $title incorrectly set up. Please check the readme for examples",
+                                [
+                                    'file' => __FILE__,
+                                    'line' => __LINE__,
+                                ]
+                            );
                             continue;
                         }
                         singleton('Symbiote\\QueuedJobs\\Services\\QueuedJobService')->queueJob(
                             Injector::inst()->createWithArgs($jobConfig['type'], $jobConfig['construct']),
                             date($jobConfig['startDateFormat'], strtotime($jobConfig['startTimeString']))
                         );
-                        $this->getLogger()->error("Default Job config: $title has been re-added to the Queue");
+                        $this->getLogger()->error(
+                            "Default Job config: $title has been re-added to the Queue",
+                            [
+                                'file' => __FILE__,
+                                'line' => __LINE__,
+                            ]
+                        );
                     }
                 }
             }
@@ -443,7 +471,13 @@ class QueuedJobService
             );
         }
 
-        $this->getLogger()->error($message);
+        $this->getLogger()->error(
+            $message,
+            [
+                'file' => __FILE__,
+                'line' => __LINE__,
+            ]
+        );
         $from = Config::inst()->get(Email::class, 'admin_email');
         $to = Config::inst()->get(Email::class, 'queued_job_admin_email');
         $subject = _t(__CLASS__ . '.STALLED_JOB', 'Stalled job');
@@ -646,7 +680,11 @@ class QueuedJobService
                                     'errcontext' => array()
                                 ),
                                 true
-                            )
+                            ),
+                            [
+                                'file' => __FILE__,
+                                'line' => __LINE__,
+                            ]
                         );
                         break;
                     }
@@ -675,7 +713,12 @@ class QueuedJobService
                                 ),
                                 'ERROR'
                             );
-                            $this->getLogger()->error($e->getMessage());
+                            $this->getLogger()->error(
+                                $e->getMessage(),
+                                [
+                                    'exception' => $e,
+                                ]
+                            );
                             $jobDescriptor->JobStatus =  QueuedJob::STATUS_BROKEN;
                         }
 
@@ -741,7 +784,11 @@ class QueuedJobService
                                     'errcontext' => array()
                                 ),
                                 true
-                            )
+                            ),
+                            [
+                                'file' => __FILE__,
+                                'line' => __LINE__,
+                            ]
                         );
                         $broken = true;
                     }
@@ -758,7 +805,12 @@ class QueuedJobService
                 }
             } catch (Exception $e) {
                 // okay, we'll just catch this exception for now
-                $this->getLogger()->error($e->getMessage());
+                $this->getLogger()->error(
+                    $e->getMessage(),
+                    [
+                        'exception' => $e,
+                    ]
+                );
                 $jobDescriptor->JobStatus =  QueuedJob::STATUS_BROKEN;
                 $jobDescriptor->write();
                 $broken = true;


### PR DESCRIPTION
## TL;DR
`RaygunHandler` requires that context is provided to it. This can either be the `Exception` itself, or values for "line" and "file".

## Example trace for an `Exception`
`QueuedJobService`
Line `702` or `806`: An `Exception` is thrown and caught.
Line `704` or `808`: Logs the Exception message (*only* the message) to `Monolog\Logger::error()`.

`Monolog\Logger`
Line `614`: `error()` accepts `string $message` and `array $context` (please note, no `$context` was passed above, so this is an empty `array`)
Line `616`: `error()` calls `addRecord()` with error level, message, and context as it's params.
Line `322`: `addRecord()` creates `$record`:
```
$record = array(
    'message' => (string) $message,
    'context' => $context,
    'level' => $level,
    'level_name' => $levelName,
    'channel' => $this->name,
    'datetime' => $ts,
    'extra' => array(),
);
```
Please note that `context` is (from the trace) an empty `array`.
Line `337`: `addRecord()` calls `$handler->handle($record)`. This `$record` eventually makes it way to `Monolog\Handler\RaygunHandler::write()`.

`Monolog\Handler\RaygunHandler::write()`
```
$context = $record['context'];

if (isset($context['exception']) &&
    (
        $context['exception'] instanceof \Exception ||
        (PHP_VERSION_ID > 70000 && $context['exception'] instanceof \Throwable)
    )
) {
    $this->writeException(
        $record,
        $record['formatted']['tags'],
        $record['formatted']['custom_data'],
        $record['formatted']['timestamp']
    );
} elseif (isset($context['file']) && $context['line']) {
    $this->writeError(
        $record['formatted'],
        $record['formatted']['tags'],
        $record['formatted']['custom_data'],
        $record['formatted']['timestamp']
    );
} else {
    throw new \InvalidArgumentException('Invalid record given.');
}
```

`$record['context']` is an empty array, so neither of the above conditions are met. `RaygunHandler` then throws an `InvalidArgumentException`.