### PR TITLE
Replace 'clipboard-pencil' font icon with 'checklist' font icon

### DIFF
--- a/src/Controllers/QueuedJobsAdmin.php
+++ b/src/Controllers/QueuedJobsAdmin.php
@@ -43,7 +43,7 @@ class QueuedJobsAdmin extends ModelAdmin
     /**
      * @var string
      */
-    private static $menu_icon_class = 'font-icon-clipboard-pencil';
+    private static $menu_icon_class = 'font-icon-checklist';
 
     /**
      * @var array


### PR DESCRIPTION
Based on the emoji tally in the [related issue](https://github.com/symbiote/silverstripe-queuedjobs/issues/162), which I interpret to make the checklist font icon the crowd's favourite, it is used as the menu icon. This resolves #162 

It looks like that:
![image](https://user-images.githubusercontent.com/14869519/38400714-936f708c-39a5-11e8-8fe4-a35ebd6a7973.png)

It works well with the other menu icons
![image](https://user-images.githubusercontent.com/14869519/38400711-8ee3d292-39a5-11e8-960c-a1bdc9b5fdce.png)

The font icon was introduced to the admin module in https://github.com/silverstripe/silverstripe-admin/commit/d5d022ec752a38c7e931694ea6fa660f2fae85c4, so an update to the admin module version dependency might be required.

@clarkepaul