### PR TITLE
Fixed a case where original user was missing when unsetting a user.

### DIFF
--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -892,13 +892,15 @@ class QueuedJobService
             } else {
                 $_SESSION['loggedInAs'] = null;
             }
+
+            return;
         }
 
         // Okay let's reset our user.
         if (Controller::has_curr()) {
             Security::setCurrentUser($originalUser);
         } else {
-            $_SESSION['loggedInAs'] = !empty($originalUser) ? $originalUser->ID : 0;
+            $_SESSION['loggedInAs'] = $originalUser->ID;
         }
     }
 


### PR DESCRIPTION
Fixed a situation where unsetting a user would generate a PHP notice because we are trying to access object property of null. This is quite annoying as one notice per job is created.