### PR TITLE
FIX Allow integration/unit tests to use more memory, update assertions and docblock tweaks

### DIFF
--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -649,6 +649,7 @@ class QueuedJobService
                     Subsite::changeSubsite($job->SubsiteID);
 
                     // lets set the base URL as far as Director is concerned so that our URLs are correct
+                    /** @var Subsite $subsite */
                     $subsite = DataObject::get_by_id(Subsite::class, $job->SubsiteID);
                     if ($subsite && $subsite->exists()) {
                         $domain = $subsite->domain();
@@ -718,8 +719,7 @@ class QueuedJobService
                                         'file' => $e->getFile(),
                                         'line' => $e->getLine(),
                                     ]
-                                ),
-                                'ERROR'
+                                )
                             );
                             $this->getLogger()->error(
                                 $e->getMessage(),
@@ -746,8 +746,7 @@ class QueuedJobService
                                     __CLASS__ . '.JOB_STALLED',
                                     'Job stalled after {attempts} attempts - please check',
                                     ['attempts' => $stallCount]
-                                ),
-                                'ERROR'
+                                )
                             );
                             $jobDescriptor->JobStatus = QueuedJob::STATUS_BROKEN;
                         }
@@ -1029,7 +1028,7 @@ class QueuedJobService
      *          The number of seconds to include jobs that have just finished, allowing a job list to be built that
      *          includes recently finished jobs
      *
-     * @return QueuedJobDescriptor
+     * @return DataList
      */
     public function getJobList($type = null, $includeUpUntil = 0)
     {


### PR DESCRIPTION
Fixes https://github.com/symbiote/silverstripe-queuedjobs/issues/190

This PR changes a couple of things:

* use assertCount for countable lists
* correct docblock return type for getJobList (returns a list not a descriptor)
* adds a couple of PHPDoc hints for class types
* removes deprecated `Config::inst()->update()` use
* removes second argument to addMessage, which doesn't exist any more