### PR TITLE
Ensure extension fields don't exist before adding them

### DIFF
--- a/src/Extensions/ScheduledExecutionExtension.php
+++ b/src/Extensions/ScheduledExecutionExtension.php
@@ -54,10 +54,18 @@ class ScheduledExecutionExtension extends DataExtension
      */
     public function updateCMSFields(FieldList $fields)
     {
+        $fields->removeByName([
+            'ExecuteInterval',
+            'ExecuteEvery',
+            'ExecuteFree',
+            'FirstExecution'
+        ]);
+
         $fields->findOrMakeTab(
             'Root.Schedule',
             _t(__CLASS__ . '.ScheduleTabTitle', 'Schedule')
         );
+
         $fields->addFieldsToTab('Root.Schedule', array(
             $dt = DatetimeField::create('FirstExecution', _t(__CLASS__ . '.FIRST_EXECUTION', 'First Execution')),
             FieldGroup::create(


### PR DESCRIPTION
When applying this extension to a scaffolded dataobject, the fields already exist in the CMS so when this runs and tries to re-add SilverStripe will throw a warning indicating those fields already exist. This ensures that the fields have been removed first.