### PR TITLE
Update QueuedJobService to use timestamps

### DIFF
--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -907,7 +907,7 @@ class QueuedJobService
     protected function markStarted()
     {
         if (!$this->startedAt) {
-            $this->startedAt = DBDatetime::now()->Format('U');
+            $this->startedAt = DBDatetime::now()->getTimestamp();
         }
     }
 
@@ -928,7 +928,7 @@ class QueuedJobService
         $this->markStarted();
 
         // Check duration
-        $now = DBDatetime::now()->Format('U');
+        $now = DBDatetime::now()->getTimestamp();
         return $now > $this->startedAt + $limit;
     }
 


### PR DESCRIPTION
As per #199 update `markstarted()` and `hasPassedTimeLimit()` to use the `getTimestamp()` method instead of formatting the time.