### PR TITLE
FIX Doorman's 'is cancelled' criteria now included completed jobs, preventing infinite processes

### DIFF
--- a/src/Jobs/DoormanQueuedJobTask.php
+++ b/src/Jobs/DoormanQueuedJobTask.php
@@ -206,6 +206,13 @@ class DoormanQueuedJobTask implements Task, Expires, Process, Cancellable
     public function isCancelled()
     {
         $this->refreshDescriptor();
-        return $this->descriptor->JobStatus === QueuedJob::STATUS_CANCELLED;
+
+        // Treat completed jobs as cancelled when it comes to how Doorman handles picking up jobs to run
+        $cancelledStates = [
+            QueuedJob::STATUS_CANCELLED,
+            QueuedJob::STATUS_COMPLETE,
+        ];
+
+        return in_array($this->descriptor->JobStatus, $cancelledStates, true);
     }
 }

--- a/tests/Jobs/DoormanQueuedJobTaskTest.php
+++ b/tests/Jobs/DoormanQueuedJobTaskTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Symbiote\QueuedJobs\Tests\Jobs;
+
+use SilverStripe\Dev\SapphireTest;
+use Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor;
+use Symbiote\QueuedJobs\Jobs\DoormanQueuedJobTask;
+use Symbiote\QueuedJobs\Services\QueuedJob;
+
+class DoormanQueuedJobTaskTest extends SapphireTest
+{
+    protected static $fixture_file = 'DoormanQueuedJobTaskTest.yml';
+
+    /**
+     * @dataProvider canRunTaskProvider
+     * @param string $status
+     * @param bool $expected
+     */
+    public function testCanRunTask($status, $expected)
+    {
+        /** @var QueuedJobDescriptor $descriptor */
+        $descriptor = $this->objFromFixture(QueuedJobDescriptor::class, 'dummy_job');
+        $descriptor->JobStatus = $status;
+        $descriptor->write();
+
+        $task = new DoormanQueuedJobTask($descriptor);
+        $this->assertSame($expected, $task->canRunTask());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function canRunTaskProvider()
+    {
+        return [
+            [QueuedJob::STATUS_NEW, true],
+            [QueuedJob::STATUS_INIT, true],
+            [QueuedJob::STATUS_WAIT, true],
+            [QueuedJob::STATUS_RUN, false],
+        ];
+    }
+
+    /**
+     * @dataProvider isCancelledProvider
+     * @param string $status
+     * @param bool $expected
+     */
+    public function testIsCancelled($status, $expected)
+    {
+        /** @var QueuedJobDescriptor $descriptor */
+        $descriptor = $this->objFromFixture(QueuedJobDescriptor::class, 'dummy_job');
+        $descriptor->JobStatus = $status;
+        $descriptor->write();
+
+        $task = new DoormanQueuedJobTask($descriptor);
+        $this->assertSame($expected, $task->isCancelled());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function isCancelledProvider()
+    {
+        return [
+            [QueuedJob::STATUS_CANCELLED, true],
+            [QueuedJob::STATUS_COMPLETE, true],
+            [QueuedJob::STATUS_INIT, false],
+        ];
+    }
+}

--- a/tests/Jobs/DoormanQueuedJobTaskTest.yml
+++ b/tests/Jobs/DoormanQueuedJobTaskTest.yml
@@ -1,0 +1,16 @@
+Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor:
+  dummy_job:
+    JobTitle: Dummy
+    Signature: 1b9dcebac8eefbef4052fe7693ee896f
+    Implementation: Symbiote\QueuedJobs\Tasks\DummyQueuedJob
+    StartAfter: 2015-01-01 09:00:00
+    JobStarted: NULL
+    JobRestarted: NULL
+    JobFinished: NULL
+    TotalSteps: 1
+    StepsProcessed: 0
+    LastProcessedCount: -1
+    ResumeCounts: 0
+    JobStatus: New
+    JobType: 2
+    RunAsID: 1


### PR DESCRIPTION
See #204 and #105

This means that when Doorman's runner detects a stalled job which is then picked up in a different process and completed, then the original doesn't continue to loop looking for jobs that aren't "cancelled" and life forever because the job is now "complete"

Resolves #105, but I'm still looking into the reason the jobs are stalling in the first place for #204