### PR TITLE
FIX Remove use of deprecated DB::getConn(), update broken doc blocks etc

### DIFF
--- a/docs/en/configuring-multi-process-execution.md
+++ b/docs/en/configuring-multi-process-execution.md
@@ -2,55 +2,54 @@
 
 You can enable multi-process execution by selecting `doorman` as the engine:
 
-	:::yaml
-	---
-	Name: myqueuedjobsconfig
-	After: '#queuedjobsettings'
-	---
-	Injector:
-	  ProcessJobQueueTask:
-	    properties:
-	      TaskRunner: %$DoormanRunner
-
+```yaml
+---
+Name: myqueuedjobsconfig
+After: '#queuedjobsettings'
+---
+SilverStripe\Core\Injector\Injector:
+  Symbiote\QueuedJobs\Services\QueuedJobService:
+    properties:
+      queueRunner: %$Symbiote\QueuedJobs\Tasks\Engines\DoormanRunner
+```
 
 By default, this will allow a single child process to complete queued jobs. You can increase the number of processes allowed by changing the default rule:
 
-
-	:::yaml
-	---
-	Name: myqueuedjobsconfig
-	---
-	Injector:
-	  LowUsageRule:
-	    class: 'AsyncPHP\Doorman\Rule\InMemoryRule'
-	    properties:
-	      Processes: 2
-	      MinimumProcessorUsage: 0
-	      MaximumProcessorUsage: 50
-	      MinimumMemoryUsage: 0
-	      MaximumMemoryUsage: 50
-	  MediumUsageRule:
-	    class: 'AsyncPHP\Doorman\Rule\InMemoryRule'
-	    properties:
-	      Processes: 1
-	      MinimumProcessorUsage: 50
-	      MaximumProcessorUsage: 75
-	      MinimumMemoryUsage: 50
-	      MaximumMemoryUsage: 75
-	  HighUsageRule:
-	    class: 'AsyncPHP\Doorman\Rule\InMemoryRule'
-	    properties:
-	      Processes: 0
-	      MinimumProcessorUsage: 75
-	      MaximumProcessorUsage: 100
-	      MinimumMemoryUsage: 75
-	      MaximumMemoryUsage: 100
-	  DoormanRunner:
-	    properties:
-	      DefaultRules:
-	        - '%LowUsageRule'
-	        - '%MediumUsageRule'
-	        - '%HighUsageRule'
-
+```yaml
+---
+Name: myqueuedjobsconfig
+---
+SilverStripe\Core\Injector\Injector:
+  LowUsageRule:
+    class: 'AsyncPHP\Doorman\Rule\InMemoryRule'
+    properties:
+      Processes: 2
+      MinimumProcessorUsage: 0
+      MaximumProcessorUsage: 50
+      MinimumMemoryUsage: 0
+      MaximumMemoryUsage: 50
+  MediumUsageRule:
+    class: 'AsyncPHP\Doorman\Rule\InMemoryRule'
+    properties:
+      Processes: 1
+      MinimumProcessorUsage: 50
+      MaximumProcessorUsage: 75
+      MinimumMemoryUsage: 50
+      MaximumMemoryUsage: 75
+  HighUsageRule:
+    class: 'AsyncPHP\Doorman\Rule\InMemoryRule'
+    properties:
+      Processes: 0
+      MinimumProcessorUsage: 75
+      MaximumProcessorUsage: 100
+      MinimumMemoryUsage: 75
+      MaximumMemoryUsage: 100
+  DoormanRunner:
+    properties:
+      DefaultRules:
+        - '%LowUsageRule'
+        - '%MediumUsageRule'
+        - '%HighUsageRule'
+```
 
 As with all parallel processing architectures, you should be aware of the race conditions that can occur. You cannot depend on a predictable order of execution, or that every process has a predictable state. Use this with caution!

--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -566,7 +566,7 @@ class QueuedJobService
             return false;
         }
 
-        if (DB::getConn()->affectedRows() === 0 && $jobDescriptor->JobStatus !== QueuedJob::STATUS_INIT) {
+        if (DB::get_conn()->affectedRows() === 0 && $jobDescriptor->JobStatus !== QueuedJob::STATUS_INIT) {
             return false;
         }
 

--- a/src/Tasks/CreateQueuedJobTask.php
+++ b/src/Tasks/CreateQueuedJobTask.php
@@ -2,9 +2,9 @@
 
 namespace Symbiote\QueuedJobs\Tasks;
 
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Dev\BuildTask;
-use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 use Symbiote\QueuedJobs\Services\QueuedJobService;
 
 /**

--- a/src/Tasks/Engines/BaseRunner.php
+++ b/src/Tasks/Engines/BaseRunner.php
@@ -5,6 +5,7 @@ namespace Symbiote\QueuedJobs\Tasks\Engines;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Convert;
 use Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
 
 /**
  * Class BaseRunner
@@ -20,7 +21,7 @@ class BaseRunner
      */
     public function getService()
     {
-        return singleton('Symbiote\\QueuedJobs\\Services\\QueuedJobService');
+        return singleton(QueuedJobService::class);
     }
 
     /**

--- a/src/Tasks/Engines/DoormanRunner.php
+++ b/src/Tasks/Engines/DoormanRunner.php
@@ -16,9 +16,9 @@ use SilverStripe\Core\Injector\Injector;
 class DoormanRunner extends BaseRunner implements TaskRunnerEngine
 {
     /**
-     * @var string
+     * @var string[]
      */
-    protected $defaultRules = array();
+    protected $defaultRules = [];
 
     /**
      * Assign default rules for this task
@@ -45,9 +45,9 @@ class DoormanRunner extends BaseRunner implements TaskRunnerEngine
      */
     public function runQueue($queue)
     {
-
         // split jobs out into multiple tasks...
 
+        /** @var ProcessManager $manager */
         $manager = Injector::inst()->create(ProcessManager::class);
         $manager->setWorker(BASE_PATH . "/vendor/silverstripe/framework/cli-script.php dev/tasks/ProcessJobQueueChildTask");
         $logPath = Environment::getEnv('SS_DOORMAN_LOGPATH');

--- a/src/Tasks/ProcessJobQueueChildTask.php
+++ b/src/Tasks/ProcessJobQueueChildTask.php
@@ -2,9 +2,9 @@
 
 namespace Symbiote\QueuedJobs\Tasks;
 
-use AsyncPHP\Doorman\Handler;
-use AsyncPHP\Doorman\Task;
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\BuildTask;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
 
 class ProcessJobQueueChildTask extends BuildTask
 {
@@ -38,6 +38,6 @@ class ProcessJobQueueChildTask extends BuildTask
      */
     protected function getService()
     {
-        return singleton('Symbiote\\QueuedJobs\\Services\\QueuedJobService');
+        return singleton(QueuedJobService::class);
     }
 }


### PR DESCRIPTION
Also updates the namespace reference in the Doorman configuration docs for Injector and switches the code block formatting to use GitHub flavoured markdown