### PR TITLE
NEW Allowing disabling health checks - adding a task for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,26 @@ Symbiote\QueuedJobs\Jobs\CleanupJob:
     - Complete
 ```
 
+## Health Checking
+
+Jobs track their execution in steps - as the job runs it increments the "steps" that have been run. Periodically jobs
+are checked to ensure they are healthy. This asserts the count of steps on a job is always increasing between health
+checks. By default health checks are performed when a worker picks starts running a queue.
+
+In a multi-worker environment this can cause issues when health checks are performed too frequently. You can disable the
+automatic health check with the following configuration:
+
+```yaml
+Symbiote\QueuedJobs\Services\QueuedJobService:
+  disable_health_check: true
+```
+
+In addition to the config setting there is a task that can be used with a cron to ensure that unhealthy jobs are
+detected:
+
+```
+*/5 * * * * php /path/to/silverstripe/vendor/bin/sake dev/tasks/CheckJobHealthTask
+```
 
 ## Troubleshooting
 

--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -82,6 +82,18 @@ class QueuedJobService
     private static $time_limit = 0;
 
     /**
+     * Disable health checks that usually occur when a runner first picks up a queue. Note that completely disabling
+     * health checks could result in many jobs that are always marked as running - that will never be restarted. If
+     * this option is disabled you may alternatively use the build task
+     *
+     * @see \Symbiote\QueuedJobs\Tasks\CheckJobHealthTask
+     *
+     * @var bool
+     * @config
+     */
+    private static $disable_health_check = false;
+
+    /**
      * Timestamp (in seconds) when the queue was started
      *
      * @var int
@@ -377,6 +389,8 @@ class QueuedJobService
                 ]
             );
         }
+
+        return $stalledJobs->count();
     }
 
     /**
@@ -1074,7 +1088,9 @@ class QueuedJobService
      */
     public function runQueue($queue)
     {
-        $this->checkJobHealth($queue);
+        if (!self::config()->disable_health_check) {
+            $this->checkJobHealth($queue);
+        }
         $this->checkdefaultJobs($queue);
         $this->queueRunner->runQueue($queue);
     }

--- a/src/Tasks/CheckJobHealthTask.php
+++ b/src/Tasks/CheckJobHealthTask.php
@@ -1,0 +1,51 @@
+<?php
+namespace Symbiote\QueuedJobs\Tasks;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Dev\BuildTask;
+use Symbiote\QueuedJobs\Services\QueuedJob;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
+
+class CheckJobHealthTask extends BuildTask
+{
+    /**
+     * {@inheritDoc}
+     * @var string
+     */
+    private static $segment = 'CheckJobHealthTask';
+
+    /**
+     * {@inheritDoc}
+     * @return string
+     */
+    public function getDescription()
+    {
+        return _t(
+            __CLASS__ . '.Description',
+            'A task used to check the health of jobs that are "running". Pass a specific queue as the "queue" ' .
+            'parameter or otherwise the "Queued" queue will be checked'
+        );
+    }
+
+    /**
+     * Implement this method in the task subclass to
+     * execute via the TaskRunner
+     *
+     * @param HTTPRequest $request
+     * @return
+     */
+    public function run($request)
+    {
+        $queue = $request->requestVar('queue') ?: QueuedJob::QUEUED;
+
+        $stalledJobCount = $this->getService()->checkJobHealth($queue);
+
+        echo $stalledJobCount === 0 ? 'All jobs are healthy' : 'Detected and attempted restart on ' . $stalledJobCount .
+            ' stalled jobs';
+    }
+
+    protected function getService()
+    {
+        return QueuedJobService::singleton();
+    }
+}


### PR DESCRIPTION
Resolves #213

This will do nothing by default. However you can now disable automated health checks with a config setting. There is also a new build task provided to do health checking - this can be set up as a cron.