### PR TITLE
NEW Include website URL in stalled jobs email as well as job ID

### DIFF
--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -434,8 +434,8 @@ class QueuedJobService
                         ]
                     );
                     Email::create()
-                        ->setTo(isset($jobConfig['email']) ? $jobConfig['email'] : Config::inst()->get('Email', 'queued_job_admin_email'))
-                        ->setFrom(Config::inst()->get('Email', 'queued_job_admin_email'))
+                        ->setTo(isset($jobConfig['email']) ? $jobConfig['email'] : Config::inst()->get(Email::class, 'queued_job_admin_email'))
+                        ->setFrom(Config::inst()->get(Email::class, 'queued_job_admin_email'))
                         ->setSubject('Default Job "' . $title . '" missing')
                         ->setData($jobConfig)
                         ->addData('Title', $title)
@@ -505,7 +505,13 @@ class QueuedJobService
         $from = Config::inst()->get(Email::class, 'admin_email');
         $to = Config::inst()->get(Email::class, 'queued_job_admin_email');
         $subject = _t(__CLASS__ . '.STALLED_JOB', 'Stalled job');
-        $mail = new Email($from, $to, $subject, $message);
+        $mail = Email::create($from, $to, $subject)
+            ->setData([
+                'JobID' => $stalledJob->ID,
+                'Message' => $message,
+                'Site' => Director::absoluteBaseURL(),
+            ])
+            ->setHTMLTemplate('QueuedJobsStalledJob');
         $mail->send();
     }
 

--- a/templates/QueuedJobsStalledJob.ss
+++ b/templates/QueuedJobsStalledJob.ss
@@ -1,0 +1,7 @@
+Hi,
+
+$Message
+
+Job ID: $JobID
+
+Log in to $Site to see further details and take any necessary actions.


### PR DESCRIPTION
Resolves #25 

The new template would look like this:

```
Hi,

A job named Content Review Notification Job appears to have stalled. It will be stopped and restarted, please login to make sure it has continued

Job ID: 2

Log in to http://cwp21.localhost/ to see further details and take any necessary actions.
```

Wording is from QueuedJobsDefaultJob.ss (existing).

Note: I can't receive any of these local emails that are fired from my local environment to my Gmail account, but I've validated that the body is rendered and that the email send result is true.