### PR TITLE
Ensure compatibility with SS 3.7 & PHP 7.2

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -3,3 +3,9 @@
 if (($QUEUED_JOBS_DIR = basename(dirname(__FILE__))) != 'queuedjobs') {
 	die("The queued jobs module must be installed in /queuedjobs, not $QUEUED_JOBS_DIR");
 }
+
+// Ensure compatibility with PHP 7.2 ("object" is a reserved word),
+// with SilverStripe 3.6 (using Object) and SilverStripe 3.7 (using SS_Object)
+if (!class_exists('SS_Object')) {
+    class_alias('Object', 'SS_Object');
+}

--- a/code/services/QueuedJobService.php
+++ b/code/services/QueuedJobService.php
@@ -426,7 +426,7 @@ class QueuedJobService {
 	protected function initialiseJob(QueuedJobDescriptor $jobDescriptor) {
 		// create the job class
 		$impl = $jobDescriptor->Implementation;
-		$job = Object::create($impl);
+		$job = SS_Object::create($impl);
 		/* @var $job QueuedJob */
 		if (!$job) {
 			throw new Exception("Implementation $impl no longer exists");


### PR DESCRIPTION
This fixes the SS 3.7+ & PHP 7.2 compatibility, effectively renaming calls to Object:: to SS_Object:: and aliasing SS_Object to Object for backwards compatibility (older versions of SilverStripe) [as described here](https://docs.silverstripe.org/en/3/changelogs/3.7.0/#for-module-authors).