### PR TITLE
FIX Add queuedjobs test state to disable the shutdown handler during unit tests

### DIFF
--- a/_config/tests.yml
+++ b/_config/tests.yml
@@ -1,0 +1,8 @@
+---
+Name: queuedjobstests
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\Dev\State\SapphireTestState:
+    properties:
+      States:
+        queuedjobsstate: '%$Symbiote\QueuedJobs\Dev\State\QueuedJobsTestState'

--- a/src/Dev/State/QueuedJobsTestState.php
+++ b/src/Dev/State/QueuedJobsTestState.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Symbiote\QueuedJobs\Dev\State;
+
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Dev\State\TestState;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
+
+class QueuedJobsTestState implements TestState
+{
+    /**
+     * Never run the shutdown handler during unit tests
+     *
+     * @param SapphireTest $test
+     */
+    public function setUp(SapphireTest $test)
+    {
+
+        Config::modify()->set(QueuedJobService::class, 'use_shutdown_function', false);
+    }
+
+    public function tearDown(SapphireTest $test)
+    {
+        // noop
+    }
+
+    public function setUpOnce($class)
+    {
+        // noop
+    }
+
+    public function tearDownOnce($class)
+    {
+        // noop
+    }
+}


### PR DESCRIPTION
Many modules using this module will need to disable this handler in their own unit tests. This PR adds a TestState which will do it globally whenever the module is installed in the project.