### PR TITLE
FIX Replace Convert JSON methods with json_* methods, deprecated from SilverStripe 4.4

### DIFF
--- a/src/QJUtils.php
+++ b/src/QJUtils.php
@@ -91,7 +91,7 @@ class QJUtils
      */
     public function ajaxResponse($message, $status)
     {
-        return Convert::raw2json(array(
+        return json_encode(array(
             'message' => $message,
             'status' => $status,
         ));

--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -254,14 +254,8 @@ class QueuedJobService
         $messages = @unserialize($jobDescriptor->SavedJobMessages);
 
         if (!$jobData) {
-            // SS's convert:: function doesn't do this detection for us!!
-            if (function_exists('json_decode')) {
-                $jobData = json_decode($jobDescriptor->SavedJobData);
-                $messages = json_decode($jobDescriptor->SavedJobMessages);
-            } else {
-                $jobData = Convert::json2obj($jobDescriptor->SavedJobData);
-                $messages = Convert::json2obj($jobDescriptor->SavedJobMessages);
-            }
+            $jobData = json_decode($jobDescriptor->SavedJobData);
+            $messages = json_decode($jobDescriptor->SavedJobMessages);
         }
 
         $job->setJobData(


### PR DESCRIPTION
Issue: https://github.com/silverstripe/silverstripe-framework/issues/8424