### PR TITLE
Provide legacy class-name map for SilverStripe 4

### DIFF
--- a/_config/legacy.yml
+++ b/_config/legacy.yml
@@ -1,0 +1,4 @@
+SilverStripe\ORM\DatabaseAdmin:
+  classname_value_remapping:
+    QueuedJobDescriptor: Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor
+    QueuedJobRule: Symbiote\QueuedJobs\DataObjects\QueuedJobRule


### PR DESCRIPTION
This provides class-name remapping for upgrades from SilverStripe 3 to
SilverStripe 4, as per Step 10 of the [upgrade guide](https://docs.silverstripe.org/en/4/upgrading/#step10).