### PR TITLE
FIX Cleanup tasks now uses Configurable and correctly re-enqueues itself

### DIFF
--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -235,7 +235,7 @@ class QueuedJobService
      * Copies data from a job into a descriptor for persisting
      *
      * @param QueuedJob $job
-     * @param JobDescriptor $jobDescriptor
+     * @param QueuedJobDescriptor $jobDescriptor
      */
     protected function copyJobToDescriptor($job, $jobDescriptor)
     {
@@ -675,6 +675,7 @@ class QueuedJobService
                 // while not finished
                 while (!$job->jobFinished() && !$broken) {
                     // see that we haven't been set to 'paused' or otherwise by another process
+                    /** @var QueuedJobDescriptor $jobDescriptor */
                     $jobDescriptor = DataObject::get_by_id(
                         QueuedJobDescriptor::class,
                         (int)$jobId


### PR DESCRIPTION
The config was not namespaced, so it would not have re-enqueued itself. I have also added some PHPDoc hints to assist with IDE type hinting in QueuedJobService.