### PR TITLE
NEW Some minor touchups to code to adhere to current SilverStripe best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,18 +64,19 @@ that processes this queue. Its time of execution can be left a little longer.
 use Symbiote\QueuedJobs\Services\QueuedJobService;
 
 $publish = new PublishItemsJob(21);
-singleton(QueuedJobService::class)->queueJob($publish);
+QueuedJobService::singleton()->queueJob($publish);
 ```
 
 * To schedule a job to be executed at some point in the future, pass a date through with the call to queueJob
 The following will run the publish job in 1 day's time from now.
 
 ```php
+use SilverStripe\ORM\FieldType\DBDatetime;
 use Symbiote\QueuedJobs\Services\QueuedJobService;
 
 $publish = new PublishItemsJob(21);
-singleton(QueuedJobService::class)
-    ->queueJob($publish, date('Y-m-d H:i:s', time() + 86400));
+QueuedJobService::singleton()
+    ->queueJob($publish, DBDatetime::create()->setValue(DBDatetime::now()->getTimestamp() + 86400)->Rfc2822());
 ```
 
 ## Using Doorman for running jobs

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,12 +2,10 @@
 <ruleset name="SilverStripe">
     <description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
 
-    <!-- base rules are PSR-2 -->
-    <rule ref="PSR2">
+    <!-- base rules are PSR-12 -->
+    <rule ref="PSR12">
         <!-- Current exclusions -->
         <exclude name="PSR1.Methods.CamelCapsMethodName"/>
         <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps"/>
-        <exclude name="Generic.Files.LineLength.TooLong"/>
     </rule>
 </ruleset>
-

--- a/src/Controllers/QueuedJobsAdmin.php
+++ b/src/Controllers/QueuedJobsAdmin.php
@@ -18,7 +18,6 @@ use SilverStripe\Forms\GridField\GridFieldDataColumns;
 use SilverStripe\Forms\GridField\GridFieldPageCount;
 use SilverStripe\Forms\GridField\GridFieldToolbarHeader;
 use SilverStripe\Forms\TextareaField;
-use SilverStripe\ORM\DataList;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\Security;
 use Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor;
@@ -97,8 +96,7 @@ class QueuedJobsAdmin extends ModelAdmin
 
         $filter = $this->jobQueue->getJobListFilter(null, self::config()->max_finished_jobs_age);
 
-        $list = DataList::create(QueuedJobDescriptor::class);
-        $list = $list->where($filter)->sort('Created', 'DESC');
+        $list = QueuedJobDescriptor::get()->where($filter)->sort('Created', 'DESC');
 
         $gridFieldConfig = GridFieldConfig_RecordEditor::create()
             ->addComponent(new GridFieldQueuedJobExecute('execute'))
@@ -144,7 +142,11 @@ class QueuedJobsAdmin extends ModelAdmin
                     unset($types[$class]);
                 }
             }
-            $jobType = DropdownField::create('JobType', _t(__CLASS__ . '.CREATE_JOB_TYPE', 'Create job of type'), $types);
+            $jobType = DropdownField::create(
+                'JobType',
+                _t(__CLASS__ . '.CREATE_JOB_TYPE', 'Create job of type'),
+                $types
+            );
             $jobType->setEmptyString('(select job to create)');
             $form->Fields()->push($jobType);
 
@@ -190,8 +192,8 @@ class QueuedJobsAdmin extends ModelAdmin
             $params = isset($data['JobParams']) ? explode(PHP_EOL, $data['JobParams']) : array();
             $time = isset($data['JobStart']) && is_array($data['JobStart']) ? implode(" ", $data['JobStart']) : null;
 
-            // If the user has select the European date format as their setting then replace '/' with '-' in the date string so PHP
-            // treats the date as this format.
+            // If the user has select the European date format as their setting then replace '/' with '-' in the
+            // date string so PHP treats the date as this format.
             if (Security::getCurrentUser()->DateFormat == self::$date_format_european) {
                 $time = str_replace('/', '-', $time);
             }

--- a/src/Controllers/QueuedTaskRunner.php
+++ b/src/Controllers/QueuedTaskRunner.php
@@ -2,7 +2,9 @@
 
 namespace Symbiote\QueuedJobs\Controllers;
 
+use SilverStripe\Admin\AdminRootController;
 use SilverStripe\Control\Director;
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\BuildTask;
@@ -45,7 +47,10 @@ class QueuedTaskRunner extends TaskRunner
         if (!Director::is_cli()) {
             $renderer = new DebugView();
             echo $renderer->renderHeader();
-            echo $renderer->renderInfo("SilverStripe Development Tools: Tasks (QueuedJobs version)", Director::absoluteBaseURL());
+            echo $renderer->renderInfo(
+                "SilverStripe Development Tools: Tasks (QueuedJobs version)",
+                Director::absoluteBaseURL()
+            );
             $base = Director::absoluteBaseURL();
 
             echo "<div class=\"options\">";
@@ -62,7 +67,8 @@ class QueuedTaskRunner extends TaskRunner
                 $immediateLink = $base . "dev/tasks/" . $task['segment'];
 
                 echo "<li><p>";
-                echo "<a href=\"$queueLink\">" . $task['title'] . "</a> <a style=\"font-size: 80%; padding-left: 20px\" href=\"$immediateLink\">[run immediately]</a><br />";
+                echo "<a href=\"$queueLink\">" . $task['title'] . "</a> <a style=\"font-size: 80%; padding-left: 20px\""
+                    . " href=\"$immediateLink\">[run immediately]</a><br />";
                 echo "<span class=\"description\">" . $task['description'] . "</span>";
                 echo "</p></li>\n";
             }
@@ -131,7 +137,8 @@ class QueuedTaskRunner extends TaskRunner
                 $jobID = Injector::inst()->get(QueuedJobService::class)->queueJob($job);
 
                 $message('Done: queued with job ID ' . $jobID);
-                $adminLink = Director::baseURL() . "admin/queuedjobs/" . str_replace('\\', '-', QueuedJobDescriptor::class);
+                $adminUrl = Director::baseURL() . AdminRootController::config()->get('url_base');
+                $adminLink = $adminUrl . "/queuedjobs/" . str_replace('\\', '-', QueuedJobDescriptor::class);
                 $message("Visit <a href=\"$adminLink\">queued jobs admin</a> to see job status");
                 return;
             }

--- a/src/Extensions/ScheduledExecutionExtension.php
+++ b/src/Extensions/ScheduledExecutionExtension.php
@@ -10,6 +10,7 @@ use SilverStripe\Forms\NumericField;
 use SilverStripe\Forms\ReadonlyField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\DataExtension;
+use SilverStripe\ORM\FieldType\DBDatetime;
 use Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor;
 use Symbiote\QueuedJobs\Jobs\ScheduledExecutionJob;
 use Symbiote\QueuedJobs\Services\QueuedJobService;
@@ -50,7 +51,7 @@ class ScheduledExecutionExtension extends DataExtension
     );
 
     /**
-     * @param FieldSet $fields
+     * @param FieldList $fields
      */
     public function updateCMSFields(FieldList $fields)
     {
@@ -122,12 +123,12 @@ class ScheduledExecutionExtension extends DataExtension
 
             if (!$this->owner->ScheduledJobID) {
                 $job = new ScheduledExecutionJob($this->owner);
-                $time = date('Y-m-d H:i:s');
+                $time = DBDatetime::now()->Rfc2822();
                 if ($this->owner->FirstExecution) {
-                    $time = date('Y-m-d H:i:s', strtotime($this->owner->FirstExecution));
+                    $time = DBDatetime::create()->setValue($this->owner->FirstExecution)->Rfc2822();
                 }
 
-                $this->owner->ScheduledJobID = singleton(QueuedJobService::class)
+                $this->owner->ScheduledJobID = QueuedJobService::singleton()
                     ->queueJob($job, $time);
             }
         }

--- a/src/Jobs/CleanupJob.php
+++ b/src/Jobs/CleanupJob.php
@@ -177,7 +177,10 @@ class CleanupJob extends AbstractQueuedJob implements QueuedJob
         if (Config::inst()->get(self::class, 'is_enabled')) {
             $this->addMessage("Queueing the next Cleanup Job.");
             $cleanup = new CleanupJob();
-            QueuedJobService::singleton()->queueJob($cleanup, date('Y-m-d H:i:s', time() + 86400));
+            QueuedJobService::singleton()->queueJob(
+                $cleanup,
+                DBDatetime::create()->setValue(DBDatetime::now()->getTimestamp() + 86400)->Rfc2822()
+            );
         }
     }
 }

--- a/src/Jobs/ScheduledExecutionJob.php
+++ b/src/Jobs/ScheduledExecutionJob.php
@@ -2,7 +2,9 @@
 
 namespace Symbiote\QueuedJobs\Jobs;
 
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\FieldType\DBDatetime;
 use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 use Symbiote\QueuedJobs\Services\QueuedJobService;
 
@@ -74,11 +76,11 @@ class ScheduledExecutionJob extends AbstractQueuedJob
             }
 
             $next = strtotime($timeStr);
-            if ($next > time()) {
+            if ($next > DBDatetime::now()->getTimestamp()) {
                 // in the future
-                $nextGen = date('Y-m-d H:i:s', $next);
-                $nextId = singleton(QueuedJobService::class)->queueJob(
-                    new ScheduledExecutionJob($object, $this->timesExecuted + 1),
+                $nextGen = DBDatetime::create()->setValue($next)->Rfc2822();
+                $nextId = QueuedJobService::singleton()->queueJob(
+                    Injector::inst()->create(ScheduledExecutionJob::class, $object, $this->timesExecuted + 1),
                     $nextGen
                 );
                 $object->ScheduledJobID = $nextId;

--- a/src/QJUtils.php
+++ b/src/QJUtils.php
@@ -3,7 +3,6 @@
 namespace Symbiote\QueuedJobs;
 
 use SilverStripe\Core\Convert;
-use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DB;
 
 /**
@@ -41,7 +40,8 @@ class QJUtils
 
             if (strpos($field, '.')) {
                 list($tb, $fl) = explode('.', $field);
-                $string .= $sep . $quoteChar . $tb . $quoteChar . '.' . $quoteChar . $fl . $quoteChar . " $operator " . $value;
+                $string .= $sep . $quoteChar . $tb . $quoteChar . '.' . $quoteChar . $fl . $quoteChar
+                    . " $operator " . $value;
             } else {
                 if (is_numeric($field)) {
                     $string .= $sep . $value;
@@ -68,8 +68,9 @@ class QJUtils
                 $return[] = $this->recursiveQuote($v);
             }
 
-            return '('.implode(',', $return).')';
-        } elseif (is_null($val)) {
+            return '(' . implode(',', $return) . ')';
+        }
+        if (is_null($val)) {
             $val = 'NULL';
         } elseif (is_int($val)) {
             $val = (int) $val;

--- a/src/Services/AbstractQueuedJob.php
+++ b/src/Services/AbstractQueuedJob.php
@@ -2,6 +2,7 @@
 
 namespace Symbiote\QueuedJobs\Services;
 
+use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\Subsites\State\SubsiteState;
 use stdClass;
 use SilverStripe\Core\Config\Config;
@@ -73,7 +74,7 @@ abstract class AbstractQueuedJob implements QueuedJob
 
     /**
      * @param string $name
-     * @return DataObject|void
+     * @return DataObject|null
      */
     protected function getObject($name = 'Object')
     {
@@ -103,7 +104,7 @@ abstract class AbstractQueuedJob implements QueuedJob
      */
     protected function randomSignature()
     {
-        return md5(get_class($this) . time() . mt_rand(0, 100000));
+        return md5(get_class($this) . DBDatetime::now()->getTimestamp() . mt_rand(0, 100000));
     }
 
     /**
@@ -237,7 +238,7 @@ abstract class AbstractQueuedJob implements QueuedJob
     public function addMessage($message, $severity = 'INFO')
     {
         $severity = strtoupper($severity);
-        $this->messages[] = '[' . date('Y-m-d H:i:s') . "][$severity] $message";
+        $this->messages[] = '[' . DBDatetime::now()->Rfc2822() . "][$severity] $message";
     }
 
     /**

--- a/src/Services/ImmediateQueueHandler.php
+++ b/src/Services/ImmediateQueueHandler.php
@@ -16,7 +16,7 @@ class ImmediateQueueHandler
      * @var array
      */
     private static $dependencies = [
-        'queuedJobService' => '%$Symbiote\\QueuedJobs\\Services\\QueuedJobService',
+        'queuedJobService' => '%$' . QueuedJobService::class,
     ];
 
     /**

--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -9,7 +9,6 @@ use SilverStripe\Control\Director;
 use SilverStripe\Control\Email\Email;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Config\Configurable;
-use SilverStripe\Core\Convert;
 use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
@@ -182,7 +181,7 @@ class QueuedJobService
             ],
         ];
 
-        $existing = DataList::create(QueuedJobDescriptor::class)
+        $existing = QueuedJobDescriptor::get()
             ->filter($filter)
             ->first();
 
@@ -218,12 +217,12 @@ class QueuedJobService
     /**
      * Start a job (or however the queue handler determines it should be started)
      *
-     * @param JobDescriptor $jobDescriptor
-     * @param date $startAfter
+     * @param QueuedJobDescriptor $jobDescriptor
+     * @param string $startAfter
      */
     public function startJob($jobDescriptor, $startAfter = null)
     {
-        if ($startAfter && strtotime($startAfter) > time()) {
+        if ($startAfter && strtotime($startAfter) > DBDatetime::now()->getTimestamp()) {
             $this->queueHandler->scheduleJob($jobDescriptor, $startAfter);
         } else {
             // immediately start it on the queue, however that works
@@ -235,7 +234,7 @@ class QueuedJobService
      * Copies data from a job into a descriptor for persisting
      *
      * @param QueuedJob $job
-     * @param JobDescriptor $jobDescriptor
+     * @param QueuedJobDescriptor $jobDescriptor
      */
     protected function copyJobToDescriptor($job, $jobDescriptor)
     {
@@ -245,7 +244,7 @@ class QueuedJobService
         $jobDescriptor->StepsProcessed = $data->currentStep;
         if ($data->isComplete) {
             $jobDescriptor->JobStatus = QueuedJob::STATUS_COMPLETE;
-            $jobDescriptor->JobFinished = date('Y-m-d H:i:s');
+            $jobDescriptor->JobFinished = DBDatetime::now()->Rfc2822();
         }
 
         $jobDescriptor->SavedJobData = serialize($data->jobData);
@@ -284,7 +283,7 @@ class QueuedJobService
      *
      * @param string $type Job type
      *
-     * @return QueuedJobDescriptor
+     * @return QueuedJobDescriptor|false
      */
     public function getNextPendingJob($type = null)
     {
@@ -295,6 +294,7 @@ class QueuedJobService
             ->sort('ID', 'ASC');
 
         // see if there's any blocked jobs that need to be resumed
+        /** @var QueuedJobDescriptor $waitingJob */
         $waitingJob = $list
             ->filter('JobStatus', QueuedJob::STATUS_WAIT)
             ->first();
@@ -312,6 +312,7 @@ class QueuedJobService
         }
 
         // Otherwise, lets find any 'new' jobs that are waiting to execute
+        /** @var QueuedJobDescriptor $newJob */
         $newJob = $list
             ->filter('JobStatus', QueuedJob::STATUS_NEW)
             ->where(sprintf(
@@ -427,7 +428,11 @@ class QueuedJobService
                         ]
                     );
                     Email::create()
-                        ->setTo(isset($jobConfig['email']) ? $jobConfig['email'] : Config::inst()->get(Email::class, 'queued_job_admin_email'))
+                        ->setTo(
+                            isset($jobConfig['email'])
+                                ? $jobConfig['email']
+                                : Config::inst()->get(Email::class, 'queued_job_admin_email')
+                        )
                         ->setFrom(Config::inst()->get(Email::class, 'admin_email'))
                         ->setSubject('Default Job "' . $title . '" missing')
                         ->setData($jobConfig)
@@ -436,7 +441,10 @@ class QueuedJobService
                         ->setHTMLTemplate('QueuedJobsDefaultJob')
                         ->send();
                     if (isset($jobConfig['recreate']) && $jobConfig['recreate']) {
-                        if (!array_key_exists('construct', $jobConfig) || !isset($jobConfig['startDateFormat']) || !isset($jobConfig['startTimeString'])) {
+                        if (!array_key_exists('construct', $jobConfig)
+                            || !isset($jobConfig['startDateFormat'])
+                            || !isset($jobConfig['startTimeString'])
+                        ) {
                             $this->getLogger()->error(
                                 "Default Job config: $title incorrectly set up. Please check the readme for examples",
                                 [
@@ -446,7 +454,7 @@ class QueuedJobService
                             );
                             continue;
                         }
-                        singleton('Symbiote\\QueuedJobs\\Services\\QueuedJobService')->queueJob(
+                        QueuedJobService::singleton()->queueJob(
                             Injector::inst()->createWithArgs($jobConfig['type'], $jobConfig['construct']),
                             date($jobConfig['startDateFormat'], strtotime($jobConfig['startTimeString']))
                         );
@@ -477,7 +485,8 @@ class QueuedJobService
             $logLevel = 'warning';
             $message = _t(
                 __CLASS__ . '.STALLED_JOB_RESTART_MSG',
-                'A job named {name} (#{id}) appears to have stalled. It will be stopped and restarted, please login to make sure it has continued',
+                'A job named {name} (#{id}) appears to have stalled. It will be stopped and restarted, please '
+                . 'login to make sure it has continued',
                 ['name' => $stalledJob->JobTitle, 'id' => $stalledJob->ID]
             );
         } else {
@@ -526,11 +535,13 @@ class QueuedJobService
      *          The Job descriptor of a job to prepare for execution
      *
      * @return QueuedJob|boolean
+     * @throws Exception
      */
     protected function initialiseJob(QueuedJobDescriptor $jobDescriptor)
     {
         // create the job class
         $impl = $jobDescriptor->Implementation;
+        /** @var QueuedJob $job */
         $job = Injector::inst()->create($impl);
         /* @var $job QueuedJob */
         if (!$job) {
@@ -602,10 +613,12 @@ class QueuedJobService
      *          The ID of the job to start executing
      *
      * @return boolean
+     * @throws Exception
      */
     public function runJob($jobId)
     {
         // first retrieve the descriptor
+        /** @var QueuedJobDescriptor $jobDescriptor */
         $jobDescriptor = DataObject::get_by_id(
             QueuedJobDescriptor::class,
             (int)$jobId
@@ -622,6 +635,7 @@ class QueuedJobService
         // We need to use $_SESSION directly because SS ties the session to a controller that no longer exists at
         // this point of execution in some circumstances
         $originalUserID = isset($_SESSION['loggedInAs']) ? $_SESSION['loggedInAs'] : 0;
+        /** @var Member|null $originalUser */
         $originalUser = $originalUserID
             ? DataObject::get_by_id(Member::class, $originalUserID)
             : null;
@@ -648,9 +662,9 @@ class QueuedJobService
 
                 // get the job ready to begin.
                 if (!$jobDescriptor->JobStarted) {
-                    $jobDescriptor->JobStarted = date('Y-m-d H:i:s');
+                    $jobDescriptor->JobStarted = DBDatetime::now()->Rfc2822();
                 } else {
-                    $jobDescriptor->JobRestarted = date('Y-m-d H:i:s');
+                    $jobDescriptor->JobRestarted = DBDatetime::now()->Rfc2822();
                 }
 
                 // Only write to job as "Running" if 'isComplete' was NOT set to true
@@ -681,6 +695,7 @@ class QueuedJobService
                 // while not finished
                 while (!$job->jobFinished() && !$broken) {
                     // see that we haven't been set to 'paused' or otherwise by another process
+                    /** @var QueuedJobDescriptor $jobDescriptor */
                     $jobDescriptor = DataObject::get_by_id(
                         QueuedJobDescriptor::class,
                         (int)$jobId
@@ -707,9 +722,11 @@ class QueuedJobService
                     }
                     if ($jobDescriptor->JobStatus != QueuedJob::STATUS_RUN) {
                         // we've been paused by something, so we'll just exit
-                        $job->addMessage(
-                            _t(__CLASS__ . '.JOB_PAUSED', 'Job paused at {time}', ['time' => date('Y-m-d H:i:s')])
-                        );
+                        $job->addMessage(_t(
+                            __CLASS__ . '.JOB_PAUSED',
+                            'Job paused at {time}',
+                            ['time' => DBDatetime::now()->Rfc2822()]
+                        ));
                         $broken = true;
                     }
 
@@ -829,6 +846,7 @@ class QueuedJobService
                 }
 
                 if ($job->jobFinished()) {
+                    /** @var AbstractQueuedJob|QueuedJob $job */
                     $job->afterComplete();
                     $jobDescriptor->cleanupJob();
                 }
@@ -1047,7 +1065,7 @@ class QueuedJobService
      *          The number of seconds to include jobs that have just finished, allowing a job list to be built that
      *          includes recently finished jobs
      *
-     * @return DataList
+     * @return DataList|QueuedJobDescriptor[]
      */
     public function getJobList($type = null, $includeUpUntil = 0)
     {
@@ -1074,7 +1092,9 @@ class QueuedJobService
 
         $filter = ['JobStatus <>' => QueuedJob::STATUS_COMPLETE];
         if ($includeUpUntil) {
-            $filter['JobFinished > '] = date('Y-m-d H:i:s', time() - $includeUpUntil);
+            $filter['JobFinished > '] = DBDatetime::create()->setValue(
+                DBDatetime::now()->getTimestamp() - $includeUpUntil
+            )->Rfc2822();
         }
 
         $filter = $util->dbQuote($filter, ' OR ');
@@ -1093,7 +1113,7 @@ class QueuedJobService
      */
     public function runQueue($queue)
     {
-        if (!self::config()->disable_health_check) {
+        if (!self::config()->get('disable_health_check')) {
             $this->checkJobHealth($queue);
         }
         $this->checkdefaultJobs($queue);

--- a/src/Tasks/DummyQueuedJob.php
+++ b/src/Tasks/DummyQueuedJob.php
@@ -2,10 +2,11 @@
 
 namespace Symbiote\QueuedJobs\Tasks;
 
+use SilverStripe\ORM\FieldType\DBDatetime;
 use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 use Symbiote\QueuedJobs\Services\QueuedJob;
 
-class DummyQueuedJob extends AbstractQueuedJob implements QueuedJob
+class DummyQueuedJob extends AbstractQueuedJob
 {
     /**
      * @param int $number
@@ -45,10 +46,11 @@ class DummyQueuedJob extends AbstractQueuedJob implements QueuedJob
     {
         $times = $this->times;
         // needed due to quirks with __set
-        $times[] = date('Y-m-d H:i:s');
+        $time = DBDatetime::now()->Rfc2822();
+        $times[] = $time;
         $this->times = $times;
 
-        $this->addMessage('Updated time to ' . date('Y-m-d H:i:s'));
+        $this->addMessage('Updated time to ' . $time);
         sleep(1);
 
         // make sure we're incrementing

--- a/src/Tasks/Engines/BaseRunner.php
+++ b/src/Tasks/Engines/BaseRunner.php
@@ -4,6 +4,7 @@ namespace Symbiote\QueuedJobs\Tasks\Engines;
 
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Convert;
+use SilverStripe\ORM\FieldType\DBDatetime;
 use Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor;
 use Symbiote\QueuedJobs\Services\QueuedJobService;
 
@@ -21,7 +22,7 @@ class BaseRunner
      */
     public function getService()
     {
-        return singleton(QueuedJobService::class);
+        return QueuedJobService::singleton();
     }
 
     /**
@@ -33,7 +34,7 @@ class BaseRunner
     protected function writeLogLine($line, $prefix = null)
     {
         if (!$prefix) {
-            $prefix = '[' . date('Y-m-d H:i:s') . '] ';
+            $prefix = '[' . DBDatetime::now()->Rfc2822() . '] ';
         }
 
         if (Director::is_cli()) {

--- a/src/Tasks/Engines/DoormanRunner.php
+++ b/src/Tasks/Engines/DoormanRunner.php
@@ -51,7 +51,9 @@ class DoormanRunner extends BaseRunner implements TaskRunnerEngine
 
         /** @var ProcessManager $manager */
         $manager = Injector::inst()->create(ProcessManager::class);
-        $manager->setWorker(BASE_PATH . "/vendor/silverstripe/framework/cli-script.php dev/tasks/ProcessJobQueueChildTask");
+        $manager->setWorker(
+            BASE_PATH . "/vendor/silverstripe/framework/cli-script.php dev/tasks/ProcessJobQueueChildTask"
+        );
         $logPath = Environment::getEnv('SS_DOORMAN_LOGPATH');
         if ($logPath) {
             $manager->setLogPath($logPath);

--- a/src/Tasks/ProcessJobQueueChildTask.php
+++ b/src/Tasks/ProcessJobQueueChildTask.php
@@ -38,6 +38,6 @@ class ProcessJobQueueChildTask extends BuildTask
      */
     protected function getService()
     {
-        return singleton(QueuedJobService::class);
+        return QueuedJobService::singleton();
     }
 }

--- a/src/Tasks/ProcessJobQueueTask.php
+++ b/src/Tasks/ProcessJobQueueTask.php
@@ -3,8 +3,8 @@
 namespace Symbiote\QueuedJobs\Tasks;
 
 use SilverStripe\Control\HTTPRequest;
-use Symbiote\QueuedJobs\Services\QueuedJob;
 use SilverStripe\Dev\BuildTask;
+use Symbiote\QueuedJobs\Services\QueuedJob;
 use Symbiote\QueuedJobs\Services\QueuedJobService;
 
 /**

--- a/src/Workers/JobWorker.php
+++ b/src/Workers/JobWorker.php
@@ -3,6 +3,9 @@
 namespace Symbiote\QueuedJobs\Workers;
 
 use SilverStripe\ORM\DataList;
+use SilverStripe\ORM\FieldType\DBDatetime;
+use Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
 
 /**
  * @author marcus@symbiote.com.au
@@ -36,10 +39,10 @@ if (interface_exists('GearmanHandler')) {
         public function jobqueueExecute($jobId)
         {
             $this->queuedJobService->checkJobHealth();
-            $job = DataList::create('Symbiote\\QueuedJobs\\DataObjects\\QueuedJobDescriptor')->byID($jobId);
+            $job = QueuedJobDescriptor::get()->byID($jobId);
             if ($job) {
                 // check that we're not trying to execute something tooo soon
-                if (strtotime($job->StartAfter) > time()) {
+                if (strtotime($job->StartAfter) > DBDatetime::now()->getTimestamp()) {
                     return;
                 }
 

--- a/tests/QueuedJobsAdminTest.php
+++ b/tests/QueuedJobsAdminTest.php
@@ -45,7 +45,7 @@ class QueuedJobsAdminTest extends FunctionalTest
         // The shutdown handler doesn't play nicely with SapphireTest's database handling
         QueuedJobService::config()->set('use_shutdown_function', false);
 
-        $this->admin = new QueuedJobsAdmin;
+        $this->admin = new QueuedJobsAdmin();
         $this->admin->setRequest(new HTTPRequest('GET', '/'));
         $this->admin->getRequest()->setSession($this->session());
 
@@ -61,7 +61,7 @@ class QueuedJobsAdminTest extends FunctionalTest
      */
     public function testConstructorParamsShouldBeATextarea()
     {
-        $fields = $this->admin->getEditForm('foo', new FieldList)->Fields();
+        $fields = $this->admin->getEditForm('foo', new FieldList())->Fields();
         $this->assertInstanceOf(TextareaField::class, $fields->fieldByName('JobParams'));
     }
 
@@ -80,7 +80,7 @@ class QueuedJobsAdminTest extends FunctionalTest
                 return $job instanceof PublishItemsJob && $job->rootID === 'foo123';
             }));
 
-        $form = $this->admin->getEditForm('foo', new FieldList);
+        $form = $this->admin->getEditForm('foo', new FieldList());
         $form->Fields()->fieldByName('JobParams')->setValue(implode(PHP_EOL, ['foo123', 'bar']));
         $form->Fields()->fieldByName('JobType')->setValue(PublishItemsJob::class);
 

--- a/tests/QueuedJobsTest.php
+++ b/tests/QueuedJobsTest.php
@@ -2,7 +2,6 @@
 
 namespace Symbiote\QueuedJobs\Tests;
 
-use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
@@ -10,8 +9,8 @@ use Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor;
 use Symbiote\QueuedJobs\Services\QueuedJob;
 use Symbiote\QueuedJobs\Services\QueuedJobService;
 use Symbiote\QueuedJobs\Tests\QueuedJobsTest\TestExceptingJob;
-use Symbiote\QueuedJobs\Tests\QueuedJobsTest\TestQueuedJob;
 use Symbiote\QueuedJobs\Tests\QueuedJobsTest\TestQJService;
+use Symbiote\QueuedJobs\Tests\QueuedJobsTest\TestQueuedJob;
 
 /**
  * @author Marcus Nyeholt <marcus@symbiote.com.au>
@@ -331,7 +330,11 @@ class QueuedJobsTest extends AbstractTest
         $this->assertEquals(0, $descriptor->StepsProcessed);
         $this->assertEquals(0, $descriptor->LastProcessedCount);
         $this->assertEquals(1, $descriptor->ResumeCounts);
-        $this->assertContains('A job named A Test job appears to have stalled. It will be stopped and restarted, please login to make sure it has continued', $logger->getMessages());
+        $this->assertContains(
+            'A job named A Test job appears to have stalled. It will be stopped and restarted, please login to '
+            . 'make sure it has continued',
+            $logger->getMessages()
+        );
 
         // Run 2 - First restart (work is done)
         $descriptor->JobStatus = QueuedJob::STATUS_RUN;
@@ -368,7 +371,11 @@ class QueuedJobsTest extends AbstractTest
         $this->assertEquals(1, $descriptor->StepsProcessed);
         $this->assertEquals(1, $descriptor->LastProcessedCount);
         $this->assertEquals(2, $descriptor->ResumeCounts);
-        $this->assertContains('A job named A Test job appears to have stalled. It will be stopped and restarted, please login to make sure it has continued', $logger->getMessages());
+        $this->assertContains(
+            'A job named A Test job appears to have stalled. It will be stopped and restarted, please login '
+            . 'to make sure it has continued',
+            $logger->getMessages()
+        );
 
         // Run 3 - Second and last restart (no work is done)
         $descriptor->JobStatus = QueuedJob::STATUS_RUN;
@@ -383,7 +390,10 @@ class QueuedJobsTest extends AbstractTest
         $descriptor = QueuedJobDescriptor::get()->byID($id);
         $this->assertEquals(QueuedJob::STATUS_PAUSED, $descriptor->JobStatus);
         $this->assertEmpty($nextJob);
-        $this->assertContains('A job named A Test job appears to have stalled. It has been paused, please login to check it', $logger->getMessages());
+        $this->assertContains(
+            'A job named A Test job appears to have stalled. It has been paused, please login to check it',
+            $logger->getMessages()
+        );
     }
 
     public function testExceptionWithMemoryExhaustion()

--- a/tests/QueuedJobsTest/TestQueuedJob.php
+++ b/tests/QueuedJobsTest/TestQueuedJob.php
@@ -2,6 +2,7 @@
 
 namespace Symbiote\QueuedJobs\Tests\QueuedJobsTest;
 
+use SilverStripe\ORM\FieldType\DBDatetime;
 use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 use Symbiote\QueuedJobs\Services\QueuedJob;
 
@@ -36,10 +37,11 @@ class TestQueuedJob extends AbstractQueuedJob implements QueuedJob
     {
         $times = $this->times;
         // needed due to quirks with __set
-        $times[] = date('Y-m-d H:i:s');
+        $time = DBDatetime::now()->Rfc2822();
+        $times[] = $time;
         $this->times = $times;
 
-        $this->addMessage("Updated time to " . date('Y-m-d H:i:s'));
+        $this->addMessage('Updated time to ' . $time);
         sleep(1);
 
         // make sure we're incrementing

--- a/tests/ScheduledExecutionTest.php
+++ b/tests/ScheduledExecutionTest.php
@@ -38,7 +38,7 @@ class ScheduledExecutionTest extends AbstractTest
 
     public function testScheduledExecutionTimes()
     {
-        $test = new TestScheduledDataObject;
+        $test = new TestScheduledDataObject();
 
         $test->Title = 'Test execute of stuff';
         $test->write();
@@ -67,7 +67,7 @@ class ScheduledExecutionTest extends AbstractTest
 
     public function testScheduledExecutionInterval()
     {
-        $test = new TestScheduledDataObject;
+        $test = new TestScheduledDataObject();
 
         $test->Title = 'Test execute at custom interval sizes';
         $test->write();


### PR DESCRIPTION
* Prefer DBDatetime over time()/date()
* Prefer ClassName::singleton() over singleton(ClassName)
* Fix incorrect doc block argument and return types
* Remove direct calls to DataList, use ORM filters from base class
* Reduce line lengths to 120 characters maximum
* Switch to PSR-12 as a base ruleset and run automated linting
* Fix dev controller where "admin" was hard coded, should be dynamic