### PR TITLE
NEW: Improve job list in admin/queuedjobs

### DIFF
--- a/src/Controllers/QueuedJobsAdmin.php
+++ b/src/Controllers/QueuedJobsAdmin.php
@@ -82,9 +82,9 @@ class QueuedJobsAdmin extends ModelAdmin
 
     /**
      * @config The number of seconds to include jobs that have finished
-     * default: 300 (5 minutes), examples: 3600(1h), 86400(1d)
+     * default: 7200 (2 hours), examples: 3600(1h), 86400(1d)
      */
-    private static $max_finished_jobs_age = 300;
+    private static $max_finished_jobs_age = 7200;
 
     /**
      * @param int $id

--- a/src/DataObjects/QueuedJobDescriptor.php
+++ b/src/DataObjects/QueuedJobDescriptor.php
@@ -129,9 +129,10 @@ class QueuedJobDescriptor extends DataObject
             'JobTitle' => _t(__CLASS__ . '.TABLE_TITLE', 'Title'),
             'Created' => _t(__CLASS__ . '.TABLE_ADDE', 'Added'),
             'JobStarted' => _t(__CLASS__ . '.TABLE_STARTED', 'Started'),
+            'JobFinished' => _t(__CLASS__ . '.TABLE_FINISHED', 'Finished'),
 //          'JobRestarted' => _t(__CLASS__ . '.TABLE_RESUMED', 'Resumed'),
             'StartAfter' => _t(__CLASS__ . '.TABLE_START_AFTER', 'Start After'),
-            'JobType' => _t(__CLASS__ . '.JOB_TYPE', 'Job Type'),
+            'JobTypeString' => _t(__CLASS__ . '.JOB_TYPE', 'Job Type'),
             'JobStatus' => _t(__CLASS__ . '.TABLE_STATUS', 'Status'),
             'LastMessage' => _t(__CLASS__ . '.TABLE_MESSAGES', 'Message'),
             'StepsProcessed' => _t(__CLASS__ . '.TABLE_NUM_PROCESSED', 'Done'),
@@ -285,6 +286,30 @@ class QueuedJobDescriptor extends DataObject
     }
 
     /**
+     * Return a string representation of the numeric JobType
+     * @return string
+     */
+    public function getJobTypeString()
+    {
+        $map = $this->getJobTypeValues();
+        return isset($map[$this->JobType]) ? $map[$this->JobType] : '(Unknown)';
+    }
+
+
+    /**
+     * Return a map of numeric JobType values to localisable string representations.
+     * @return array
+     */
+    public function getJobTypeValues()
+    {
+        return [
+            QueuedJob::IMMEDIATE => _t(__CLASS__ . '.TYPE_IMMEDIATE', 'Immediate'),
+            QueuedJob::QUEUED => _t(__CLASS__ . '.TYPE_QUEUED', 'Queued'),
+            QueuedJob::LARGE => _t(__CLASS__ . '.TYPE_LARGE', 'Large'),
+        ];
+    }
+
+    /**
      * @return FieldList
      */
     public function getCMSFields()
@@ -292,11 +317,7 @@ class QueuedJobDescriptor extends DataObject
         $fields = parent::getCMSFields();
         $fields->replaceField(
             'JobType',
-            new DropdownField('JobType', $this->fieldLabel('JobType'), [
-                QueuedJob::IMMEDIATE => 'Immediate',
-                QueuedJob::QUEUED => 'Queued',
-                QueuedJob::LARGE => 'Large',
-            ])
+            new DropdownField('JobType', $this->fieldLabel('JobType'), $this->getJobTypeValues())
         );
         $statuses = [
             QueuedJob::STATUS_NEW,


### PR DESCRIPTION
 - Translate the job type from a number to a string
 - Add “finished”, which can be useful for seeing job duration