### PR TITLE
minor - log information to info instead of error

### DIFF
--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -422,7 +422,7 @@ class QueuedJobService
                     $jobConfig['filter']
                 ));
                 if (!$job->count()) {
-                    $this->getLogger()->error(
+                    $this->getLogger()->info(
                         "Default Job config: $title was missing from Queue",
                         [
                             'file' => __FILE__,


### PR DESCRIPTION
When queuing default job, log to info() instead of error()