### PR TITLE
Extensibility options improvements.

### DIFF
--- a/src/Services/AbstractQueuedJob.php
+++ b/src/Services/AbstractQueuedJob.php
@@ -117,6 +117,11 @@ abstract class AbstractQueuedJob implements QueuedJob
         return QueuedJob::QUEUED;
     }
 
+    public function getRunAsMemberID()
+    {
+        return null;
+    }
+
     /**
      * Performs setup tasks the first time this job is run.
      *

--- a/src/Services/QueuedJob.php
+++ b/src/Services/QueuedJob.php
@@ -85,6 +85,23 @@ interface QueuedJob
     public function getJobType();
 
     /**
+     * Specifies what user ID should be when running the job
+     * valid values:
+     * null - (default) - run the job as current user
+     * 0 - run the job without a user
+     * greater than zero - run the job as a specific user
+     *
+     * This is useful in situations like:
+     * - a job needs to always run without a user (like a static cache job)
+     * - a job needs to run as a specific user (for example data migration job)
+     *
+     * Note that this value can be overriden in the @see QueuedJobService::queueJob()
+     *
+     * @return int|null
+     */
+    public function getRunAsMemberID();
+
+    /**
      * A job is run within an external processing loop that will call this method while there are still steps left
      * to complete in the job.
      *

--- a/src/Tasks/Engines/DoormanRunner.php
+++ b/src/Tasks/Engines/DoormanRunner.php
@@ -9,6 +9,7 @@ use Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor;
 use Symbiote\QueuedJobs\Jobs\DoormanQueuedJobTask;
 use Symbiote\QueuedJobs\Services\QueuedJob;
 use SilverStripe\Core\Injector\Injector;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
 
 /**
  * Runs all jobs through the doorman engine
@@ -47,6 +48,13 @@ class DoormanRunner extends BaseRunner implements TaskRunnerEngine
      */
     public function runQueue($queue)
     {
+        // check if queue can be processed
+        $service = QueuedJobService::singleton();
+        if ($service->isAtMaxJobs()) {
+            $service->getLogger()->info('Not processing queue as jobs are at max initialisation limit.');
+            return;
+        }
+
         // split jobs out into multiple tasks...
 
         /** @var ProcessManager $manager */


### PR DESCRIPTION
Multiple extensibility options added:

* `getRunAsMemberID` configuration - this allows the jobs to be run without a user (job level configurable)
* `max_init_jobs` option added - prevents too many jobs to be in the `init` state
* `updateJobDescriptorBeforeQueued ` extension point added - this allows custom DB columns to be populated before the job is queued (used for data that can't be present in the serialized job data like identifiers for example)
* `updateJobDescriptorAndJobOnCompletion` extension point added - this is useful for `dependent` jobs, i.e. jobs that are queued only after other jobs finish
* PHP 7 exception handling added - type errors were not handled properly before


Compatibility notes:

* jobs that do not extend `AbstractQueuedJob` need to add the `getRunAsMemberID` function
* if userID was `0` during `queueJob` it won't be replaced by current user ID, use `null` instead if you want previous behaviour