### PR TITLE
Log severity and original date in queue messages

### DIFF
--- a/src/Services/QueuedJobHandler.php
+++ b/src/Services/QueuedJobHandler.php
@@ -57,7 +57,7 @@ class QueuedJobHandler extends AbstractProcessingHandler
     public function handleBatch(array $records)
     {
         foreach ($records as $record) {
-            $this->job->addMessage($record['message']);
+            $this->job->addMessage($record['message'], $record['level_name'], $record['datetime']);
         };
         $this->jobDescriptor->SavedJobMessages = serialize($this->job->getJobData()->messages);
 


### PR DESCRIPTION
The severity was set to INFO, which is a bug: It masks the actual severity of the log message,
for example ERROR or ALERT.

~Recording the datetime of addMessage() as the current datetime is also a bug:
It masks the actual date when the message was recorded, which could be many seconds
earlier due to message batching. This can in turn mask issues around slow executions,
e.g. during the file migration tasks for which this layer was introduced.
Note that the QueuedJob interface which AbstractQueuedJob implements does not have this new third argument. There's already precedent for adding optional arguments to the interface with $severity.~