### PR TITLE
Queued jobs pause setting added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,22 @@ Symbiote\QueuedJobs\Jobs\CleanupJob:
     - Complete
 ```
 
+## Jobs queue pause setting
+
+It's possible to enable a setting which allows the pausing of the queued jobs processing. To enable it, add following code to your config YAML file:
+
+```yaml
+Symbiote\QueuedJobs\Services\QueuedJobService:
+  lock_file_enabled: true
+  lock_file_path: '/shared-folder-path'
+```
+
+`Queue settings` tab will appear in the CMS settings and there will be an option to pause the queued jobs processing. If enabled, no new jobs will start running however, the jobs already running will be left to finish.
+ This is really useful in case of planned downtime like queue jobs related third party service maintenance or DB restore / backup operation.
+
+Note that this maintenance lock state is stored in a file. This is intentionally not using DB as a storage as it may not be available during some maintenance operations.
+Please make sure that the `lock_file_path` is pointing to a folder on a shared drive in case you are running a server with multiple instances.
+
 ## Health Checking
 
 Jobs track their execution in steps - as the job runs it increments the "steps" that have been run. Periodically jobs

--- a/_config/queuedjobs.yml
+++ b/_config/queuedjobs.yml
@@ -25,6 +25,10 @@ SilverStripe\Core\Injector\Injector:
       DefaultRules:
         - '%$DefaultRule'
 
+SilverStripe\SiteConfig\SiteConfig:
+  extensions:
+    - Symbiote\QueuedJobs\Extensions\MaintenanceLockExtension
+
 ---
 Name: gearman_queue_settings
 Only:

--- a/src/Extensions/MaintenanceLockExtension.php
+++ b/src/Extensions/MaintenanceLockExtension.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Symbiote\QueuedJobs\Extensions;
+
+use SilverStripe\Forms\CheckboxField;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\ORM\DataExtension;
+use SilverStripe\SiteConfig\SiteConfig;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
+
+/**
+ * Class MaintenanceLockExtension
+ * Adds a maintenance lock UI to SiteConfig
+ *
+ * @property SiteConfig|$this owner
+ * @package Symbiote\QueuedJobs\Extensions
+ */
+class MaintenanceLockExtension extends DataExtension
+{
+    /**
+     * @param FieldList $fields
+     */
+    public function updateCMSFields(FieldList $fields)
+    {
+        if (!QueuedJobService::config()->get('lock_file_enabled')) {
+            return;
+        }
+
+        $fields->addFieldsToTab('Root.QueueSettings', [
+            $lockField = CheckboxField::create(
+                'MaintenanceLockEnabled',
+                _t(__CLASS__ . '.LOCK_ENABLED', 'Maintenance Lock Enabled'),
+                QueuedJobService::singleton()->isMaintenanceLockActive()
+            ),
+        ]);
+
+        $lockField->setDescription(
+            _t(
+                __CLASS__ . '.LOCK_DESCRIPTION',
+                'Enable maintenance lock to prevent new queued jobs from being started'
+            )
+        );
+    }
+
+    /**
+     * @param bool $value
+     */
+    public function saveMaintenanceLockEnabled($value)
+    {
+        if (!QueuedJobService::config()->get('lock_file_enabled')) {
+            return;
+        }
+
+        if ($value && !QueuedJobService::singleton()->isMaintenanceLockActive()) {
+            QueuedJobService::singleton()->enableMaintenanceLock();
+        }
+
+        if (!$value && QueuedJobService::singleton()->isMaintenanceLockActive()) {
+            QueuedJobService::singleton()->disableMaintenanceLock();
+        }
+    }
+}

--- a/src/Tasks/Engines/QueueRunner.php
+++ b/src/Tasks/Engines/QueueRunner.php
@@ -3,6 +3,7 @@
 namespace Symbiote\QueuedJobs\Tasks\Engines;
 
 use Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
 
 /**
  * Runs all jobs in a queue loop in one process
@@ -14,6 +15,10 @@ class QueueRunner extends BaseRunner implements TaskRunnerEngine
      */
     public function runQueue($queue)
     {
+        if (QueuedJobService::singleton()->isMaintenanceLockActive()) {
+            return;
+        }
+
         $service = $this->getService();
 
         $nextJob = $service->getNextPendingJob($queue);

--- a/src/Tasks/ProcessJobQueueTask.php
+++ b/src/Tasks/ProcessJobQueueTask.php
@@ -37,6 +37,10 @@ class ProcessJobQueueTask extends BuildTask
      */
     public function run($request)
     {
+        if (QueuedJobService::singleton()->isMaintenanceLockActive()) {
+            return;
+        }
+
         $service = $this->getService();
 
         if ($request->getVar('list')) {

--- a/tests/MaintenanceLockTest.php
+++ b/tests/MaintenanceLockTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Symbiote\QueuedJobs\Tests;
+
+use SilverStripe\Control\Director;
+use SilverStripe\Core\Config\Config;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
+
+/**
+ * Class MaintenanceLockTest
+ *
+ * @package Symbiote\QueuedJobs\Tests
+ */
+class MaintenanceLockTest extends AbstractTest
+{
+    /**
+     * @param $lockFileEnabled
+     * @param $fileExists
+     * @param $lockActive
+     * @dataProvider maintenanceCaseProvider
+     */
+    public function testEnableMaintenanceIfActive($lockFileEnabled, $fileExists, $lockActive)
+    {
+        $fileName = 'test-lock.txt';
+        $filePath = Director::baseFolder() . DIRECTORY_SEPARATOR . $fileName;
+
+        Config::modify()->set(QueuedJobService::class, 'lock_file_enabled', $lockFileEnabled);
+        Config::modify()->set(QueuedJobService::class, 'lock_file_path', '');
+        Config::modify()->set(QueuedJobService::class, 'lock_file_name', $fileName);
+
+        QueuedJobService::singleton()->enableMaintenanceLock();
+
+        $this->assertEquals($fileExists, file_exists($filePath));
+        $this->assertEquals($lockActive, QueuedJobService::singleton()->isMaintenanceLockActive());
+
+        QueuedJobService::singleton()->disableMaintenanceLock();
+        $this->assertFalse(file_exists($filePath));
+        $this->assertFalse(QueuedJobService::singleton()->isMaintenanceLockActive());
+    }
+
+    /**
+     * @return array
+     */
+    public function maintenanceCaseProvider()
+    {
+        return [
+            [
+                false,
+                false,
+                false,
+            ],
+            [
+                true,
+                true,
+                true,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
**Queued jobs pause setting added**

* this new feature adds a UI to `SiteConfig` which allows the jobs queue to be paused
* this is a `soft` pause, which means it actually lets the running jobs to finish, but prevents new jobs from starting
* very useful for planned downtime
* note that the maintenance lock status is not saved in DB which is intentional
* this is because downtime can be caused by DB restore operation which changes the whole DB
* pausing the jobs the DB restore is very helpful when moving `prod` DB to other `non-prod` environments as it prevents possible data corruption (the jobs can start running before the DB restoration is complete)
* also, some jobs may need to be cleared or updated when moved to another environment (such as absolute URLs), this can be done before the jobs are unpaused
* this feature can be enabled / disabled and is disabled by default