### PR TITLE
User context interface separated out of QueuedJob interface.

### DIFF
--- a/src/Interfaces/UserContextInterface.php
+++ b/src/Interfaces/UserContextInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Symbiote\QueuedJobs\Interfaces;
+
+/**
+ * Interface UserContextInterface
+ * used for jobs which need to specify which member to log in when running the jobs
+ *
+ * example cases:
+ * initial site migration (special user needs to be used at all times)
+ * jobs that require no user to be logged in
+ *
+ * @package Symbiote\QueuedJobs\Interfaces
+ */
+interface UserContextInterface
+{
+    /**
+     * Specifies what user ID should be when running the job
+     * valid values:
+     * null - (default) - run the job as current user
+     * 0 - run the job without a user
+     * greater than zero - run the job as a specific user
+     *
+     * This is useful in situations like:
+     * - a job needs to always run without a user (like a static cache job)
+     * - a job needs to run as a specific user (for example data migration job)
+     *
+     * Note that this value can be overridden in the @see QueuedJobService::queueJob()
+     *
+     * @return int|null
+     */
+    public function getRunAsMemberID();
+}

--- a/src/Services/AbstractQueuedJob.php
+++ b/src/Services/AbstractQueuedJob.php
@@ -2,11 +2,12 @@
 
 namespace Symbiote\QueuedJobs\Services;
 
+use SilverStripe\Core\Config\Config;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\Subsites\State\SubsiteState;
 use stdClass;
-use SilverStripe\Core\Config\Config;
-use SilverStripe\ORM\DataObject;
+use Symbiote\QueuedJobs\Interfaces\UserContextInterface;
 
 /**
  * A base implementation of a queued job that provides some convenience for implementations
@@ -19,7 +20,7 @@ use SilverStripe\ORM\DataObject;
  * @license BSD http://silverstripe.org/bsd-license/
  * @skipUpgrade
  */
-abstract class AbstractQueuedJob implements QueuedJob
+abstract class AbstractQueuedJob implements QueuedJob, UserContextInterface
 {
     /**
      * @var stdClass

--- a/src/Services/QueuedJob.php
+++ b/src/Services/QueuedJob.php
@@ -85,23 +85,6 @@ interface QueuedJob
     public function getJobType();
 
     /**
-     * Specifies what user ID should be when running the job
-     * valid values:
-     * null - (default) - run the job as current user
-     * 0 - run the job without a user
-     * greater than zero - run the job as a specific user
-     *
-     * This is useful in situations like:
-     * - a job needs to always run without a user (like a static cache job)
-     * - a job needs to run as a specific user (for example data migration job)
-     *
-     * Note that this value can be overriden in the @see QueuedJobService::queueJob()
-     *
-     * @return int|null
-     */
-    public function getRunAsMemberID();
-
-    /**
      * A job is run within an external processing loop that will call this method while there are still steps left
      * to complete in the job.
      *

--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -23,6 +23,7 @@ use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
 use SilverStripe\Subsites\Model\Subsite;
 use Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor;
+use Symbiote\QueuedJobs\Interfaces\UserContextInterface;
 use Symbiote\QueuedJobs\QJUtils;
 use Symbiote\QueuedJobs\Tasks\Engines\TaskRunnerEngine;
 
@@ -240,7 +241,7 @@ class QueuedJobService
         $jobDescriptor->StartAfter = $startAfter;
 
         // no user provided - fallback to job user default
-        if ($userId === null) {
+        if ($userId === null && $job instanceof UserContextInterface) {
             $userId = $job->getRunAsMemberID();
         }
 


### PR DESCRIPTION
Fixes https://github.com/symbiote/silverstripe-queuedjobs/issues/261
Followup to https://github.com/symbiote/silverstripe-queuedjobs/pull/247

`UserContextInterface` functionality separated out so it would prevent a breaking change.