### PR TITLE
FIX ignored "Start After" option when creating new Queued Job in CMS

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,5 +7,6 @@
         <!-- Current exclusions -->
         <exclude name="PSR1.Methods.CamelCapsMethodName"/>
         <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps"/>
+        <exclude name="PSR12.Properties.ConstantVisibility.NotFound"/>
     </rule>
 </ruleset>

--- a/src/Controllers/QueuedJobsAdmin.php
+++ b/src/Controllers/QueuedJobsAdmin.php
@@ -190,7 +190,12 @@ class QueuedJobsAdmin extends ModelAdmin
         if (Permission::check('ADMIN')) {
             $jobType = isset($data['JobType']) ? $data['JobType'] : '';
             $params = isset($data['JobParams']) ? explode(PHP_EOL, $data['JobParams']) : array();
-            $time = isset($data['JobStart']) && is_array($data['JobStart']) ? implode(" ", $data['JobStart']) : null;
+
+            if (isset($data['JobStart'])) {
+                $time = is_array($data['JobStart']) ? implode(' ', $data['JobStart']) : $data['JobStart'];
+            } else {
+                $time = null;
+            }
 
             // If the user has select the European date format as their setting then replace '/' with '-' in the
             // date string so PHP treats the date as this format.

--- a/src/DataObjects/QueuedJobDescriptor.php
+++ b/src/DataObjects/QueuedJobDescriptor.php
@@ -151,10 +151,12 @@ class QueuedJobDescriptor extends DataObject
      */
     public function pause($force = false)
     {
-        if ($force || in_array(
-            $this->JobStatus,
-            [QueuedJob::STATUS_WAIT, QueuedJob::STATUS_RUN, QueuedJob::STATUS_INIT]
-        )) {
+        if (
+            $force || in_array(
+                $this->JobStatus,
+                [QueuedJob::STATUS_WAIT, QueuedJob::STATUS_RUN, QueuedJob::STATUS_INIT]
+            )
+        ) {
             $this->JobStatus = QueuedJob::STATUS_PAUSED;
             $this->write();
             return true;
@@ -196,7 +198,8 @@ class QueuedJobDescriptor extends DataObject
     public function activateOnQueue()
     {
         // if it's an immediate job, lets cache it to disk to be picked up later
-        if ($this->JobType == QueuedJob::IMMEDIATE
+        if (
+            $this->JobType == QueuedJob::IMMEDIATE
             && !Config::inst()->get(QueuedJobService::class, 'use_shutdown_function')
         ) {
             touch($this->getJobDir() . '/queuedjob-' . $this->ID);

--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -530,7 +530,8 @@ class QueuedJobService
                     }
 
                     if (isset($jobConfig['recreate']) && $jobConfig['recreate']) {
-                        if (!array_key_exists('construct', $jobConfig)
+                        if (
+                            !array_key_exists('construct', $jobConfig)
                             || !isset($jobConfig['startDateFormat'])
                             || !isset($jobConfig['startTimeString'])
                         ) {

--- a/src/Tasks/CheckJobHealthTask.php
+++ b/src/Tasks/CheckJobHealthTask.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Symbiote\QueuedJobs\Tasks;
 
 use SilverStripe\Control\HTTPRequest;


### PR DESCRIPTION
Creating new Job in CMS Admin ignores Start at (after) field 
 - this cause problem in production: instead of delayed run, the job/task is executed almost immediately 

![image](https://user-images.githubusercontent.com/45079648/68523462-79778680-031e-11ea-99d0-c3dbfab0fdba.png)
