### PR TITLE
BUG Explictely register HTTPRequest with Injector in test setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 env:
   global:
     - COMPOSER_ROOT_VERSION="4.3.x-dev"
@@ -7,9 +9,9 @@ env:
 matrix:
   include:
     - php: 5.6
-      env: DB=MYSQL RECIPE_VERSION=1.0.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=~1.0.0 PHPCS_TEST=1 PHPUNIT_TEST=1
     - php: 7.0
-      env: DB=PGSQL RECIPE_VERSION=1.1.x-dev PHPUNIT_TEST=1
+      env: DB=PGSQL RECIPE_VERSION=~1.1.0 PHPUNIT_TEST=1
     - php: 7.1
       env: DB=MYSQL RECIPE_VERSION=4.2.x-dev PHPUNIT_TEST=1
     - php: 7.2

--- a/src/DataObjects/QueuedJobDescriptor.php
+++ b/src/DataObjects/QueuedJobDescriptor.php
@@ -151,10 +151,12 @@ class QueuedJobDescriptor extends DataObject
      */
     public function pause($force = false)
     {
-        if ($force || in_array(
-            $this->JobStatus,
-            [QueuedJob::STATUS_WAIT, QueuedJob::STATUS_RUN, QueuedJob::STATUS_INIT]
-        )) {
+        if (
+            $force || in_array(
+                $this->JobStatus,
+                [QueuedJob::STATUS_WAIT, QueuedJob::STATUS_RUN, QueuedJob::STATUS_INIT]
+            )
+        ) {
             $this->JobStatus = QueuedJob::STATUS_PAUSED;
             $this->write();
             return true;
@@ -196,7 +198,8 @@ class QueuedJobDescriptor extends DataObject
     public function activateOnQueue()
     {
         // if it's an immediate job, lets cache it to disk to be picked up later
-        if ($this->JobType == QueuedJob::IMMEDIATE
+        if (
+            $this->JobType == QueuedJob::IMMEDIATE
             && !Config::inst()->get(QueuedJobService::class, 'use_shutdown_function')
         ) {
             touch($this->getJobDir() . '/queuedjob-' . $this->ID);

--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -443,7 +443,8 @@ class QueuedJobService
                         ->setHTMLTemplate('QueuedJobsDefaultJob')
                         ->send();
                     if (isset($jobConfig['recreate']) && $jobConfig['recreate']) {
-                        if (!array_key_exists('construct', $jobConfig)
+                        if (
+                            !array_key_exists('construct', $jobConfig)
                             || !isset($jobConfig['startDateFormat'])
                             || !isset($jobConfig['startTimeString'])
                         ) {

--- a/src/Tasks/CheckJobHealthTask.php
+++ b/src/Tasks/CheckJobHealthTask.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Symbiote\QueuedJobs\Tasks;
 
 use SilverStripe\Control\HTTPRequest;

--- a/tests/QueuedJobsAdminTest.php
+++ b/tests/QueuedJobsAdminTest.php
@@ -4,6 +4,7 @@ namespace Symbiote\QueuedJobs\Tests;
 
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\FunctionalTest;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TextareaField;
@@ -46,8 +47,10 @@ class QueuedJobsAdminTest extends FunctionalTest
         QueuedJobService::config()->set('use_shutdown_function', false);
 
         $this->admin = new QueuedJobsAdmin();
-        $this->admin->setRequest(new HTTPRequest('GET', '/'));
-        $this->admin->getRequest()->setSession($this->session());
+        $request = new HTTPRequest('GET', '/');
+        $request->setSession($this->session());
+        Injector::inst()->registerService($request, HTTPRequest::class);
+        $this->admin->setRequest($request);
 
         $mockQueue = $this->createMock(QueuedJobService::class);
         $this->admin->jobQueue = $mockQueue;


### PR DESCRIPTION
Update the QueuedJobsAdminTest to explicitly register the fake HTTPRequest with the Injector.

This is causing problems for CWP Kitchen sink because some other LeftAndMain controller gets loaded and expects a valid request, but then it fails because it can't find one.

This should fix parts of the broken builds on the Kitchen sink for 2.2 and up.