### PR TITLE
BUG Squash linting warning about constant visibility

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,5 +7,6 @@
         <!-- Current exclusions -->
         <exclude name="PSR1.Methods.CamelCapsMethodName"/>
         <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps"/>
+        <exclude name="PSR12.Properties.ConstantVisibility.NotFound"/>
     </rule>
 </ruleset>


### PR DESCRIPTION
Suppress warning linting warning about constant visibility. This can't be fixed because the module need to work with PHP 5.6