### PR TITLE
FIX Replace deprecated curly brace access syntax

### DIFF
--- a/src/DataObjects/QueuedJobDescriptor.php
+++ b/src/DataObjects/QueuedJobDescriptor.php
@@ -215,7 +215,7 @@ class QueuedJobDescriptor extends DataObject
     {
         // make sure our temp dir is in place. This is what will be inotify watched
         $jobDir = Config::inst()->get(QueuedJobService::class, 'cache_dir');
-        if ($jobDir{0} !== '/') {
+        if ($jobDir[0] !== '/') {
             $jobDir = TEMP_FOLDER . '/' . $jobDir;
         }
 


### PR DESCRIPTION
This syntax throws notices in PHP 7.4.